### PR TITLE
Fix: handling empty reports

### DIFF
--- a/nck/readers/adobe_reader.py
+++ b/nck/readers/adobe_reader.py
@@ -196,10 +196,6 @@ class AdobeReader(Reader):
 
         def result_generator():
             if data:
-                for record in data:
-                    yield record
-            # Returning an empty generator if report is empty
-            else:
-                yield from ()
+                yield from data
 
         yield JSONStream("results_" + idf, result_generator())


### PR DESCRIPTION
### Issue

- [x] My PR addresses the following Issue: JIRA [SGD-272](https://artefactory.atlassian.net/browse/SGD-272?atlOrigin=eyJpIjoiYzgxMzM5MWQ4M2ViNDYxN2E3MDEwODljOTUyZDI0NGIiLCJwIjoiaiJ9))

### Description

Handles the case when no data is returned by Adobe Reporting API 1.4:
- [x] Returns an empty generator (read method)
- [x] Creates an empty GCS file when combined with the write_gcs command