### PR TITLE
Adobe Reader 1.4: moving from WSSE to JWT auth

### DIFF
--- a/nck/helpers/adobe_helper.py
+++ b/nck/helpers/adobe_helper.py
@@ -133,6 +133,12 @@ def parse(raw_response):
                 yield {header: None for header in headers}
 
 
+class ReportDescriptionError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        logging.error(message)
+
+
 class ReportNotReadyError(Exception):
     def __init__(self, message):
         super().__init__(message)

--- a/nck/helpers/adobe_helper_2_0.py
+++ b/nck/helpers/adobe_helper_2_0.py
@@ -19,9 +19,6 @@
 import logging
 from datetime import datetime
 
-logging.basicConfig(level="INFO")
-logger = logging.getLogger()
-
 
 class APIRateLimitError(Exception):
     def __init__(self, message):

--- a/nck/readers/README.md
+++ b/nck/readers/README.md
@@ -367,9 +367,9 @@ As of May 2020 (last update of this section of the documentation), **two version
 #### How to obtain credentials
 
 Both Adobe Analytics Readers use the **JWT authentication framework**.
-- Get developper access to Adobe Analytics (documentation can be found [here](https://helpx.adobe.com/enterprise/using/manage-developers.html))
-- Create a Service Account integration to Adobe Analytics on [Adobe Developper Console](https://console.adobe.io/)
-- Use the generated JWT credentials (Client ID, Client Secret, Technical Account ID, Organization ID and private.key file) to retrieve your Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md')). All these parameters will be passed to Adobe Analytics Readers.
+- Get developer access to Adobe Analytics (documentation can be found [here](https://helpx.adobe.com/enterprise/using/manage-developers.html))
+- Create a Service Account integration to Adobe Analytics on [Adobe Developer Console](https://console.adobe.io/)
+- Use the generated JWT credentials (Client ID, Client Secret, Technical Account ID, Organization ID and private.key file) to retrieve your Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md)). All these parameters will be passed to Adobe Analytics Readers.
 
 ### Adobe Analytics Reader 1.4
 
@@ -385,12 +385,12 @@ python nck/entrypoint.py read_adobe --adobe-client-id <CLIENT_ID> --adobe-client
 
 |CLI option|Documentation|
 |--|--|
-|`--adobe-client-id`|Client ID, that you can find on Adobe Developper Console|
-|`--adobe-client-secret`|Client Secret, that you can find on Adobe Developper Console|
-|`--adobe-tech-account-id`|Technical Account ID, that you can find on Adobe Developper Console|
-|`--adobe-org-id`|Organization ID, that you can find on Adobe Developper Console|
+|`--adobe-client-id`|Client ID, that you can find on Adobe Developer Console|
+|`--adobe-client-secret`|Client Secret, that you can find on Adobe Developer Console|
+|`--adobe-tech-account-id`|Technical Account ID, that you can find on Adobe Developer Console|
+|`--adobe-org-id`|Organization ID, that you can find on Adobe Developer Console|
 |`--adobe-private-key`|Content of the private.key file, that you had to provide to create the integration. Make sure to enter the parameter in quotes, include headers, and indicate newlines as \n.|
-|`--adobe-global-company-id`|Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md'))|
+|`--adobe-global-company-id`|Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md))|
 |`--adobe-list-report-suite`|Should be set to *True* if you wish to request the list of available Adobe Report Suites (*default: False*). If set to *True*, the below parameters should be left empty.|
 |`--adobe-report-suite-id`|ID of the requested Adobe Report Suite|
 |`--adobe-report-element-id`|ID of the element (i.e. dimension) to include in the report|
@@ -418,12 +418,12 @@ python nck/entrypoint.py read_adobe_2_0 --adobe-2-0-client-id <CLIENT_ID> --adob
 
 |CLI option|Documentation|
 |--|--|
-|`--adobe-2-0-client-id`|Client ID, that you can find on Adobe Developper Console|
-|`--adobe-2-0-client-secret`|Client Secret, that you can find on Adobe Developper Console|
-|`--adobe-2-0-tech-account-id`|Technical Account ID, that you can find on Adobe Developper Console|
-|`--adobe-2-0-org-id`|Organization ID, that you can find on Adobe Developper Console|
+|`--adobe-2-0-client-id`|Client ID, that you can find on Adobe Developer Console|
+|`--adobe-2-0-client-secret`|Client Secret, that you can find on Adobe Developer Console|
+|`--adobe-2-0-tech-account-id`|Technical Account ID, that you can find on Adobe Developer Console|
+|`--adobe-2-0-org-id`|Organization ID, that you can find on Adobe Developer Console|
 |`--adobe-2-0-private-key`|Content of the private.key file, that you had to provide to create the integration. Make sure to enter the parameter in quotes, include headers, and indicate newlines as \n.|
-|`--adobe-2-0-global-company-id`|Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md'))|
+|`--adobe-2-0-global-company-id`|Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md))|
 |`--adobe-2-0-report-suite-id`|ID of the requested Adobe Report Suite|
 |`--adobe-2-0-dimension`|Dimension to include in the report|
 |`--adobe-2-0-metric`|Metric  to include in the report|

--- a/nck/readers/README.md
+++ b/nck/readers/README.md
@@ -364,26 +364,33 @@ Detailed version [here](https://tech.yandex.com/direct/doc/reports/spec-docpage/
 
 As of May 2020 (last update of this section of the documentation), **two versions of Adobe Analytics Reporting API are  coexisting: 1.4 and 2.0**. As some functionalities of API 1.4 have not been made available in API 2.0 yet (Data Warehouse reports in particular), our Adobe Analytics Readers are also available in these two versions.
 
-### Adobe Analytics Reader 1.4
-
 #### How to obtain credentials
 
-Our Adobe Analytics Reader 1.4 uses the **WSSE authentication framework**. This authentication framework is now deprecated, so you won't be able to generate new WSSE authentication credentials (Username, Password) on Adobe Developper Console if you don't already have them.
+Both Adobe Analytics Readers use the **JWT authentication framework**.
+- Get developper access to Adobe Analytics (documentation can be found [here](https://helpx.adobe.com/enterprise/using/manage-developers.html))
+- Create a Service Account integration to Adobe Analytics on [Adobe Developper Console](https://console.adobe.io/)
+- Use the generated JWT credentials (Client ID, Client Secret, Technical Account ID, Organization ID and private.key file) to retrieve your Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md')). All these parameters will be passed to Adobe Analytics Readers.
+
+### Adobe Analytics Reader 1.4
 
 #### Quickstart
 
 Call example to Adobe Analytics Reader 1.4, getting the number of visits per day and tracking code for a specified Report Suite, between 2020-01-01 and 2020-01-31:
 
 ```
-python nck/entrypoint.py read_adobe --adobe-username <USERNAME>  --adobe-password <PASSWORD> --adobe-report-suite-id <REPORT_SUITE_ID> --adobe-date-granularity day --adobe-report-element-id trackingcode --adobe-report-metric-id visits --adobe-start-date 2020-01-01 --adobe-end-date 2020-01-31 write_console
+python nck/entrypoint.py read_adobe --adobe-client-id <CLIENT_ID> --adobe-client-secret <CLIENT_SECRET> --adobe-tech-account-id <TECH_ACCOUNT_ID> --adobe-org-id <ORG_ID> --adobe-private-key <PRIVATE_KEY> --adobe-global-company-id <GLOBAL_COMPANY_ID> --adobe-report-suite-id <REPORT_SUITE_ID> --adobe-date-granularity day --adobe-report-element-id trackingcode --adobe-report-metric-id visits --adobe-start-date 2020-01-01 --adobe-end-date 2020-01-31 write_console
 ```
 
 #### Parameters
 
 |CLI option|Documentation|
 |--|--|
-|`--adobe-username`|Username used for WSSE authentication|
-|`--adobe-password`|Password used for WSSE authentication|
+|`--adobe-client-id`|Client ID, that you can find on Adobe Developper Console|
+|`--adobe-client-secret`|Client Secret, that you can find on Adobe Developper Console|
+|`--adobe-tech-account-id`|Technical Account ID, that you can find on Adobe Developper Console|
+|`--adobe-org-id`|Organization ID, that you can find on Adobe Developper Console|
+|`--adobe-private-key`|Content of the private.key file, that you had to provide to create the integration. Make sure to enter the parameter in quotes, include headers, and indicate newlines as \n.|
+|`--adobe-global-company-id`|Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md'))|
 |`--adobe-list-report-suite`|Should be set to *True* if you wish to request the list of available Adobe Report Suites (*default: False*). If set to *True*, the below parameters should be left empty.|
 |`--adobe-report-suite-id`|ID of the requested Adobe Report Suite|
 |`--adobe-report-element-id`|ID of the element (i.e. dimension) to include in the report|
@@ -399,36 +406,29 @@ python nck/entrypoint.py read_adobe --adobe-username <USERNAME>  --adobe-passwor
 
 ### Adobe Analytics Reader 2.0
 
-#### How to obtain credentials
-
-Adobe Analytics Reader 2.0 uses the **JWT authentication framework**.
-- Get developper access to Adobe Analytics (documentation can be found [here](https://helpx.adobe.com/enterprise/using/manage-developers.html))
-- Create a Service Account integration to Adobe Analytics on [Adobe Developper Console](https://console.adobe.io/)
-- Use the generated JWT credentials (Client ID, Client Secret, Technical Account ID, Organization ID and private.key file) to retrieve your Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md')). All these parameters will be passed to Adobe Analytics Reader 2.0.
-
 #### Quickstart
 
 Call example to Adobe Analytics Reader 2.0, getting the number of visits per day and tracking code for a specified Report Suite, between 2020-01-01 and 2020-01-31:
 
 ```
-python nck/entrypoint.py read_adobe_2_0 --adobe-client-id <CLIENT_ID> --adobe-client-secret <CLIENT_SECRET> --adobe-tech-account-id <TECH_ACCOUNT_ID> --adobe-org-id <ORG_ID> --adobe-private-key <PRIVATE_KEY> --adobe-global-company-id <GLOBAL_COMPANY_ID> --adobe-report-suite-id <REPORT_SUITE_ID> --adobe-dimension daterangeday --adobe-dimension campaign --adobe-start-date 2020-01-01 --adobe-end-date 2020-01-31 --adobe-metric visits write_console
+python nck/entrypoint.py read_adobe_2_0 --adobe-2-0-client-id <CLIENT_ID> --adobe-2-0-client-secret <CLIENT_SECRET> --adobe-2-0-tech-account-id <TECH_ACCOUNT_ID> --adobe-2-0-org-id <ORG_ID> --adobe-2-0-private-key <PRIVATE_KEY> --adobe-2-0-global-company-id <GLOBAL_COMPANY_ID> --adobe-2-0-report-suite-id <REPORT_SUITE_ID> --adobe-2-0-dimension daterangeday --adobe-2-0-dimension campaign --adobe-2-0-start-date 2020-01-01 --adobe-2-0-end-date 2020-01-31 --adobe-2-0-metric visits write_console
 ```
 
 #### Parameters
 
 |CLI option|Documentation|
 |--|--|
-|`--adobe-client-id`|Client ID, that you can find on Adobe Developper Console|
-|`--adobe-client-secret`|Client Secret, that you can find on Adobe Developper Console|
-|`--adobe-tech-account-id`|Technical Account ID, that you can find on Adobe Developper Console|
-|`--adobe-org-id`|Organization ID, that you can find on Adobe Developper Console|
-|`--adobe-private-key`|Content of the private.key file, that you had to provide to create the integration. Make sure to enter the parameter in quotes, include headers, and indicate newlines as \n.|
-|`--adobe-global-company-id`|Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md'))|
-|`--adobe-report-suite-id`|ID of the requested Adobe Report Suite|
-|`--adobe-dimension`|Dimension to include in the report|
-|`--adobe-metric`|Metric  to include in the report|
-|`--adobe-start-date`|Start date of the report (format: YYYY-MM-DD)|
-|`--adobe-end-date`|End date of the report (format: YYYY-MM-DD)|
+|`--adobe-2-0-client-id`|Client ID, that you can find on Adobe Developper Console|
+|`--adobe-2-0-client-secret`|Client Secret, that you can find on Adobe Developper Console|
+|`--adobe-2-0-tech-account-id`|Technical Account ID, that you can find on Adobe Developper Console|
+|`--adobe-2-0-org-id`|Organization ID, that you can find on Adobe Developper Console|
+|`--adobe-2-0-private-key`|Content of the private.key file, that you had to provide to create the integration. Make sure to enter the parameter in quotes, include headers, and indicate newlines as \n.|
+|`--adobe-2-0-global-company-id`|Global Company ID (to be requested to [Discovery API](https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md'))|
+|`--adobe-2-0-report-suite-id`|ID of the requested Adobe Report Suite|
+|`--adobe-2-0-dimension`|Dimension to include in the report|
+|`--adobe-2-0-metric`|Metric  to include in the report|
+|`--adobe-2-0-start-date`|Start date of the report (format: YYYY-MM-DD)|
+|`--adobe-2-0-end-date`|End date of the report (format: YYYY-MM-DD)|
 
 #### Additional information
 

--- a/nck/readers/adobe_reader.py
+++ b/nck/readers/adobe_reader.py
@@ -29,7 +29,7 @@ from nck.utils.args import extract_args
 from nck.utils.retry import retry
 from nck.streams.json_stream import JSONStream
 from nck.clients.adobe_client import AdobeClient
-from nck.helpers.adobe_helper import ReportNotReadyError, parse
+from nck.helpers.adobe_helper import ReportDescriptionError, ReportNotReadyError, parse
 
 from click import ClickException
 
@@ -261,9 +261,12 @@ class AdobeReader(Reader):
             idf = "list_rps"
         else:
             query_rep = self.query_report()
-            rep_id = query_rep["reportID"]
-            data = self.download_report(rep_id)
-            idf = "report_" + str(rep_id)
+            if query_rep.get("error"):
+                raise ReportDescriptionError(query_rep)
+            else:
+                rep_id = query_rep["reportID"]
+                data = self.download_report(rep_id)
+                idf = "report_" + str(rep_id)
 
         def result_generator():
             if data:

--- a/tests/readers/test_adobe_reader.py
+++ b/tests/readers/test_adobe_reader.py
@@ -21,41 +21,47 @@ from unittest import TestCase, mock
 
 
 class AdobeReaderTest(TestCase):
+
     DATEFORMAT = "%Y-%m-%d"
 
-    @mock.patch("nck.readers.adobe_reader.AdobeReader.query_report")
-    @mock.patch("nck.readers.adobe_reader.AdobeReader.download_report")
-    def test_read(self, mock_download_report, mock_query_report):
-        elt_ids = ["category", "geocountry"]
-        mets_ids = [
-            "cartadditions",
-            "cartviews",
-            "cartremovals",
-            "participationunits",
-            "participationrevenue",
-            "visits",
-            "pageviews",
-            "event46",
-            "event26",
-            "event35",
-        ]
-        rsuid = "sssamsung4ae"
-        kwargs = {
-            "username": "",
-            "password": "",
-            "report_suite_id": rsuid,
-            "date_granularity": "day",
-            "report_element_id": elt_ids,
-            "report_metric_id": mets_ids,
-            "start_date": datetime.datetime(2019, 11, 15),
-            "end_date": datetime.datetime(2019, 11, 20),
-        }
-        reader = AdobeReader(**kwargs)
+    elt_ids = ["trackingcode", "channel"]
+    mets_ids = [
+        "cartadditions",
+        "cartviews",
+        "cartremovals",
+        "participationunits",
+        "participationrevenue",
+        "visits",
+        "pageviews",
+        "event46",
+        "event26",
+        "event35",
+    ]
+    kwargs = {
+        "client_id": "",
+        "client_secret": "",
+        "tech_account_id": "",
+        "org_id": "",
+        "private_key": "",
+        "global_company_id": "",
+        "report_suite_id": "XXXXX",
+        "date_granularity": "day",
+        "report_element_id": elt_ids,
+        "report_metric_id": mets_ids,
+        "start_date": datetime.datetime(2020, 1, 1),
+        "end_date": datetime.datetime(2020, 1, 3),
+    }
 
-        def test_read_empty_data(mock_download_report, mock_query_report):
-            mock_download_report.return_value = [{"responseAgregationType": "byPage"}]
-            mock_query_report.return_value = {"reportID": "0"}
-            if len(list(reader.read())) > 1:
-                assert False, "Data is not empty"
-
-        test_read_empty_data(mock_download_report, mock_query_report)
+    @mock.patch("nck.clients.adobe_client.AdobeClient.__init__", return_value=None)
+    @mock.patch(
+        "nck.readers.adobe_reader.AdobeReader.query_report",
+        return_value={"reportID": "XXXXX"},
+    )
+    @mock.patch(
+        "nck.readers.adobe_reader.AdobeReader.download_report", return_value=None
+    )
+    def test_read_empty_data(
+        self, mock_adobe_client, mock_query_report, mock_download_report
+    ):
+        reader = AdobeReader(**self.kwargs)
+        self.assertFalse(len(list(reader.read())) > 1)


### PR DESCRIPTION
Moving from WSSE to JWT authentication (that we are already using with Adobe Reader 2.0), as WSSE is now deprecated.