### PR TITLE
Facebook Reader : Batch Requests on Ad Management queries

### DIFF
--- a/nck/helpers/facebook_helper.py
+++ b/nck/helpers/facebook_helper.py
@@ -16,14 +16,9 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import config
 import logging
-from tenacity import (
-    retry as _retry,
-    wait_exponential,
-    stop_after_delay,
-    before_sleep_log,
-)
+import json
+from time import sleep
 
 from facebook_business.adobjects.adsinsights import AdsInsights
 
@@ -42,15 +37,6 @@ ACTION_BREAKDOWNS = [
     for k, v in AdsInsights.ActionBreakdowns.__dict__.items()
     if not k.startswith("__")
 ]
-
-
-def facebook_retry(fn):
-    return _retry(
-        wait=wait_exponential(multiplier=60, min=60, max=1200),
-        stop=stop_after_delay(3600),
-        reraise=True,
-        before_sleep=before_sleep_log(config.logger, logging.INFO),
-    )(fn)
 
 
 def get_action_breakdown_filters(field_path):
@@ -173,3 +159,43 @@ def get_field_values(resp_obj, field_path, action_breakdowns, visited=[]):
             return get_all_action_breakdown_values(
                 resp_obj, visited[:-1], action_breakdowns, filters
             )
+
+
+def generate_batches(iterable, batch_size):
+    """
+    Yields lists of length size batch_size,
+    containing objects yielded by the iterable.
+    """
+
+    batch = []
+    for obj in iterable:
+        if len(batch) == batch_size:
+            yield batch
+            batch = []
+        batch.append(obj)
+
+    if len(batch):
+        yield batch
+
+
+def monitor_usage(response):
+    """
+    Extracts "X-Business-Use-Case-Usage" header from a FacebookResponse object.
+    If one of the 3 API usage rates (call_count, total_cputime, total_time)
+    is above 75%, puts the program to sleep for 5 minutes.
+    Documentation: https://developers.facebook.com/docs/graph-api/overview/rate-limiting/
+    """
+
+    for header in response._headers:
+        if header["name"] == "X-Business-Use-Case-Usage":
+            usage_header = json.loads(header["value"])
+            usage_header_values = list(usage_header.values())[0][0]
+            usage_rates = [
+                v
+                for k, v in usage_header_values.items()
+                if k in ["call_count", "total_cputime", "total_time"]
+            ]
+
+    if max(usage_rates) > 75:
+        logging.info("75% rate limit reached. Sleeping for 5 minutes...")
+        sleep(300)

--- a/nck/readers/README.md
+++ b/nck/readers/README.md
@@ -14,14 +14,14 @@ Each reader role is to read data from external source and transform it into a St
 
 #### Quickstart
 
-The Facebook Reader handles calls to 2 endpoints of the Facebook Marketing API: **Facebook Ad Insights** (to retrieve performance data), and **Facebook Object Node** (to retrieve configuration data).
+The Facebook Reader handles calls to 2 endpoints of the Facebook Marketing API: **Facebook Ad Insights** (to retrieve performance data), and **Facebook Ad Management** (to retrieve configuration data).
 
-*Example of Facebook Ad Insights Request*
+*Example of Ad Insights Request*
 ```
 python nck/entrypoint.py read_facebook --facebook-access-token <ACCESS_TOKEN> --facebook-object-id <OBJECT_ID> --facebook-breakdown age --facebook-breakdown gender --facebook-action-breakdown action_type --facebook-field ad_id --facebook-field ad_name --facebook-field impressions --facebook-field clicks --facebook-field actions[action_type:post_engagement] --facebook-field actions[action_type:video_view] --facebook-field age --facebook-field gender --facebook-time-increment 1 --facebook-start-date 2020-01-01 --facebook-end-date 2020-01-03 write_console
 ```
 
-*Example of Facebook Object Node Request*
+*Example of Ad Management Request*
 ```
 python nck/entrypoint.py read_facebook --facebook-access-token <ACCESS_TOKEN> --facebook-object-id <OBJECT_ID>  --facebook-ad-insights False --facebook-level ad --facebook-field id --facebook-field creative[id] --facebook-add-date-to-report True --facebook-start-date 2020-01-01 --facebook-end-date 2019-01-01 write_console
 ```
@@ -33,18 +33,18 @@ python nck/entrypoint.py read_facebook --facebook-access-token <ACCESS_TOKEN> --
 |`--facebook-app-id`|Facebook App ID. *Not mandatory if Facebook Access Token is provided.*|
 |`--facebook-app-secret`|Facebook App Secret. *Not mandatory if Facebook Access Token is provided.*|
 |`--facebook-access-token`|Facebook App Access Token.|
-|`--facebook-object-type`|Nature of the root Facebook Object used to make the request. *Supported values: creative (available only for Facebook Object Node requests), ad, adset, campaign, account (default).*|
+|`--facebook-object-type`|Nature of the root Facebook Object used to make the request. *Supported values: creative (available only for Ad Management requests), ad, adset, campaign, account (default).*|
 |`--facebook-object-id`|ID of the root Facebook Object used to make the request.|
-|`--facebook-level`|Granularity of the response. *Supported values: creative (available only for Facebook Object Node requests), ad (default), adset, campaign or account.*|
-|`--facebook-ad-insights`|*True* (default) if *Facebook Ad Insights* request, *False* if *Facebook Object Node* request.|
+|`--facebook-level`|Granularity of the response. *Supported values: creative (available only for Ad Management requests), ad (default), adset, campaign or account.*|
+|`--facebook-ad-insights`|*True* (default) if *Ad Insights* request, *False* if *Ad Management* request.|
 |`--facebook-field`|Fields to be retrieved.|
-|`--facebook-start-date`|Start date of the requested time range. *This parameter is only relevant for Facebook Ad Insights Requests, and Facebook Object Node requests at the Campaign, Adset and Ad levels.*|
-|`--facebook-end-date`|End date of the requested time range. *This parameter is only relevant for Facebook Ad Insights Requests, and Facebook Object Node requests at the Campaign, Adset and Ad levels.*|
-|`--facebook-date-preset`|Relative time range. Ignored if *--facebook-start date* and *--facebook-end-date* are specified. *This parameter is only relevant for Facebook Ad Insights Requests, and Facebook Object Node requests at the Campaign, Adset and Ad levels.*|
-|`--facebook-time-increment`|Cuts the results between smaller time slices within the specified time range. *This parameter is only relevant for Facebook Ad Insights Requests, and Facebook Object Node requests at the Campaign, Adset and Ad levels.*|
+|`--facebook-start-date`|Start date of the requested time range. *This parameter is only relevant for Ad Insights Requests, and Ad Management requests at the Campaign, Adset and Ad levels.*|
+|`--facebook-end-date`|End date of the requested time range. *This parameter is only relevant for Ad Insights Requests, and Ad Management requests at the Campaign, Adset and Ad levels.*|
+|`--facebook-date-preset`|Relative time range. Ignored if *--facebook-start date* and *--facebook-end-date* are specified. *This parameter is only relevant for Ad Insights Requests, and Ad Management requests at the Campaign, Adset and Ad levels.*|
+|`--facebook-time-increment`|Cuts the results between smaller time slices within the specified time range. *This parameter is only relevant for Ad Insights Requests, and Ad Management requests at the Campaign, Adset and Ad levels.*|
 |`--facebook-add-date-to-report`|*True* if you wish to add the date of the request to each response record, *False* otherwise (default).|
-|`--facebook-breakdown`|How to break down the result. *This parameter is only relevant for Facebook Ad Insights Requests.*|
-|`--facebook-action-breakdown`|How to break down action results. *This parameter is only relevant for Facebook Ad Insights Requests.*|
+|`--facebook-breakdown`|How to break down the result. *This parameter is only relevant for Ad Insights Requests.*|
+|`--facebook-action-breakdown`|How to break down action results. *This parameter is only relevant for Ad Insights Requests.*|
 
 #### Additional details for a relevant use of the Facebook Reader
 
@@ -62,8 +62,8 @@ python nck/entrypoint.py read_facebook --facebook-access-token <ACCESS_TOKEN> --
 
 2.1. The list of **applicable fields** can be found on the links below:
 
-- **Facebook Ad Insights Request**: [all fields](https://developers.facebook.com/docs/marketing-api/insights/parameters/v7.0)
-- **Facebook Object Node Request**: [Account-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-account), [Campaign-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group), [Adset-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign), [Ad-level fields](https://developers.facebook.com/docs/marketing-api/reference/adgroup), [Creative-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-creative)
+- **Ad Insights Request**: [all fields](https://developers.facebook.com/docs/marketing-api/insights/parameters/v7.0)
+- **Ad Management Request**: [Account-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-account), [Campaign-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group), [Adset-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign), [Ad-level fields](https://developers.facebook.com/docs/marketing-api/reference/adgroup), [Creative-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-creative)
 
 2.2. If you want to select **a nested field value**,  simply indicate the path to this value within the request field.
 
@@ -92,7 +92,7 @@ python nck/entrypoint.py read_facebook --facebook-access-token <ACCESS_TOKEN> --
 {"object_story_spec_video_data_call_to_action_value_link": "https://www.artefact.com"}
 ```
 
-(2.3) **Action Breakdown filters** can be applied to the fields of ***Facebook Ad Insights* Requests** using the following syntax: <FIELD_NAME>[<ACTION_BREAKDOWN>:<ACTION_BREAKDOWN_VALUE>]. You can combine multiple Action Breakdown filters on the same field by adding them in cascade next to each other.
+(2.3) **Action Breakdown filters** can be applied to the fields of ***Ad Insights* Requests** using the following syntax: <FIELD_NAME>[<ACTION_BREAKDOWN>:<ACTION_BREAKDOWN_VALUE>]. You can combine multiple Action Breakdown filters on the same field by adding them in cascade next to each other.
 
 *Facebook Reader Request*
 ```

--- a/nck/readers/facebook_reader.py
+++ b/nck/readers/facebook_reader.py
@@ -33,7 +33,8 @@ from nck.helpers.facebook_helper import (
     ACTION_BREAKDOWNS,
     get_action_breakdown_filters,
     get_field_values,
-    facebook_retry,
+    generate_batches,
+    monitor_usage,
 )
 
 from facebook_business.api import FacebookAdsApi
@@ -59,6 +60,15 @@ EDGE_MAPPING = {
     "adset": ["ad", "creative"],
     "ad": ["creative"],
 }
+
+EDGE_QUERY_MAPPING = {
+    "campaign": lambda obj: obj.get_campaigns(),
+    "adset": lambda obj: obj.get_ad_sets(),
+    "ad": lambda obj: obj.get_ads(),
+    "creative": lambda obj: obj.get_ad_creatives(),
+}
+
+BATCH_SIZE_LIMIT = 50
 
 
 def check_object_id(ctx, param, values):
@@ -148,14 +158,18 @@ class FacebookReader(Reader):
         date_preset,
         add_date_to_report,
     ):
+        # Authentication inputs
         self.app_id = app_id
         self.app_secret = app_secret
         self.access_token = access_token
+        self.api = FacebookAdsApi.init(self.app_id, self.app_secret, self.access_token)
 
+        # Level inputs
         self.object_ids = object_id
         self.object_type = object_type
         self.level = level
 
+        # Report inputs
         self.ad_insights = ad_insights
         self.breakdowns = list(breakdown)
         self.action_breakdowns = list(action_breakdown)
@@ -165,13 +179,27 @@ class FacebookReader(Reader):
             {f[0] for f in self._field_paths if f[0] not in self.breakdowns}
         )
 
+        # Date inputs
         self.time_increment = time_increment or False
         self.start_date = start_date
         self.end_date = end_date
         self.date_preset = date_preset
         self.add_date_to_report = add_date_to_report
 
-        # Check input parameters
+        # Validate inputs
+        self.validate_inputs()
+
+    def validate_inputs(self):
+        """
+        Validate combination of input parameters (triggered in FacebookReader constructor).
+        """
+        self.validate_object_type_and_level_combination()
+        self.validate_ad_insights_level()
+        self.validate_ad_insights_breakdowns()
+        self.validate_ad_insights_action_breakdowns()
+        self.validate_ad_management_inputs()
+
+    def validate_object_type_and_level_combination(self):
 
         if (self.level != self.object_type) and (
             self.level not in EDGE_MAPPING[self.object_type]
@@ -181,14 +209,18 @@ class FacebookReader(Reader):
                 Please choose level from: {[self.object_type] + EDGE_MAPPING[self.object_type]}"
             )
 
-        if self.ad_insights:
+    def validate_ad_insights_level(self):
 
+        if self.ad_insights:
             if self.level == "creative" or self.object_type == "creative":
                 raise ClickException(
-                    f"Wrong query. The 'creative' level is not available in AdInsights queries.\
+                    f"Wrong query. The 'creative' level is not available in Ad Insights queries.\
                     Accepted levels: {FACEBOOK_OBJECTS[1:]}"
                 )
 
+    def validate_ad_insights_breakdowns(self):
+
+        if self.ad_insights:
             missing_breakdowns = {
                 f[0]
                 for f in self._field_paths
@@ -199,6 +231,9 @@ class FacebookReader(Reader):
                     f"Wrong query. Please add to Breakdowns: {missing_breakdowns}"
                 )
 
+    def validate_ad_insights_action_breakdowns(self):
+
+        if self.ad_insights:
             missing_action_breakdowns = {
                 flt
                 for f in self._field_paths
@@ -210,23 +245,24 @@ class FacebookReader(Reader):
                     f"Wrong query. Please add to Action Breakdowns: {missing_action_breakdowns}"
                 )
 
-        else:
+    def validate_ad_management_inputs(self):
 
+        if not self.ad_insights:
             if self.breakdowns != [] or self.action_breakdowns != []:
                 raise ClickException(
-                    "Wrong query. Facebook Object Node queries do not accept Breakdowns nor Action Breakdowns."
+                    "Wrong query. Ad Management queries do not accept Breakdowns nor Action Breakdowns."
                 )
 
             if self.time_increment:
                 raise ClickException(
-                    "Wrong query. Facebook Object Node queries do not accept the time_increment parameter."
+                    "Wrong query. Ad Management queries do not accept the time_increment parameter."
                 )
 
     def get_params(self):
         """
         Build the request parameters that will be sent to the API:
-        - If AdInsights query: breakdown, action_breakdowns, level, time_range and date_preset
-        - If Facebook Object Node query at the campaign, adset or ad level: time_range and date_preset
+        - If Ad Insights query: breakdown, action_breakdowns, level, time_range and date_preset
+        - If Ad Management query at the campaign, adset or ad level: time_range and date_preset
         """
         params = {}
 
@@ -246,9 +282,9 @@ class FacebookReader(Reader):
     def add_period_to_params(self, params):
         """
         Add the time_increment, time_range and/or date_preset keys to parameters.
-        - time_increment: available in AdInsights queries
-        - time_range and date_preset: available in AdInsights queries,
-        and in Facebook Object Node queries at the campaign, adset or ad levels only
+        - time_increment: available in Ad Insights queries
+        - time_range and date_preset: available in Ad Insights queries,
+        and in Ad Management queries at the campaign, adset or ad levels only
         """
         if self.ad_insights and self.time_increment:
             params["time_increment"] = self.time_increment
@@ -282,27 +318,49 @@ class FacebookReader(Reader):
 
         return obj
 
-    @facebook_retry
-    def get_object_node_edges(self, obj):
-        EDGE_QUERY_MAPPING = {
-            "campaign": obj.get_campaigns,
-            "adset": obj.get_ad_sets,
-            "ad": obj.get_ads,
-            "creative": obj.get_ad_creatives,
-        }
-        return EDGE_QUERY_MAPPING[self.level]()
+    def get_edge_obj_records(self, edge_objs, fields, params):
+        """
+        Make batch Ad Management requests on a set of edge objects.
+        """
 
-    @facebook_retry
-    def get_object_node_record(self, obj, fields, params):
-        return obj.api_get(fields=fields, params=params)
+        total_edge_objs = edge_objs._total_count
+        total_batches = total_edge_objs // BATCH_SIZE_LIMIT + 1
+        logging.info(
+            f"Making {total_batches} batch requests on a total of {total_edge_objs} {self.level}s"
+        )
 
-    @facebook_retry
-    def get_ad_insights_record(self, obj, fields, params):
-        return obj.get_insights(fields=fields, params=params)
+        for batch in generate_batches(edge_objs, BATCH_SIZE_LIMIT):
+
+            # Create batch
+            api_batch = self.api.new_batch()
+            batch_responses = []
+
+            # Add each campaign request to batch
+            for edge_obj in batch:
+
+                def callback_success(response):
+                    batch_responses.append(response.json())
+                    monitor_usage(response)
+
+                def callback_failure(response):
+                    raise response.error()
+
+                edge_obj.api_get(
+                    fields=fields,
+                    params=params,
+                    batch=api_batch,
+                    success=callback_success,
+                    failure=callback_failure,
+                )
+
+            # Execute batch
+            api_batch.execute()
+
+            yield from batch_responses
 
     def query_ad_insights(self, fields, params, object_id):
         """
-        AdInsights documentation:
+        Ad Insights documentation:
         https://developers.facebook.com/docs/marketing-api/insights
         """
 
@@ -313,37 +371,30 @@ class FacebookReader(Reader):
         # Step 1 - Create Facebook object
         obj = self.create_object(object_id)
 
-        # Step 2 - Run AdInsights query on Facebook object
-        for element in self.get_ad_insights_record(obj, fields, params):
-            yield element
+        # Step 2 - Run Ad Insights query on Facebook object
+        yield from obj.get_insights(fields=fields, params=params)
 
-    def query_object_node(self, fields, params, object_id):
+    def query_ad_management(self, fields, params, object_id):
         """
-        Supported Facebook Object Nodes: AdAccount, Campaign, AdSet, Ad and AdCreative
-        Documentation: https://developers.facebook.com/docs/marketing-api/reference/
+        Ad Management documentation:
+        https://developers.facebook.com/docs/marketing-api/reference/
+        Supported object nodes: AdAccount, Campaign, AdSet, Ad and AdCreative
         """
 
         logging.info(
-            f"Running Facebook Object Node query on {self.object_type}_id: {object_id}"
+            f"Running Ad Management query on {self.object_type}_id: {object_id}"
         )
 
         # Step 1 - Create Facebook object
         obj = self.create_object(object_id)
 
-        # Step 2 - Run Facebook Object Node query on the Facebook object itself,
+        # Step 2 - Run Ad Management query on the Facebook object itself,
         # or on one of its edges (depending on the specified level)
         if self.level == self.object_type:
-            yield self.get_object_node_record(obj, fields, params)
+            yield obj.api_get(fields=fields, params=params)
         else:
-            edge_objs = self.get_object_node_edges(obj)
-            logging.info(
-                f"Making requests on {edge_objs._total_count} {self.level}s (edges of {self.object_type}_id: {object_id})"
-            )
-            for element in [
-                self.get_object_node_record(edge_obj, fields, params)
-                for edge_obj in edge_objs
-            ]:
-                yield element
+            edge_objs = EDGE_QUERY_MAPPING[self.level](obj)
+            yield from self.get_edge_obj_records(edge_objs, fields, params)
 
     def format_and_yield(self, record):
         """
@@ -368,18 +419,18 @@ class FacebookReader(Reader):
         Parse all records into an {item: value} dictionnary.
         """
         for record in data:
-            yield from self.format_and_yield(record.export_all_data())
+            yield from self.format_and_yield(record)
 
     def get_data_for_object(self, object_id):
         """
-        Run an API query (AdInsights or Facebook Object Node) on a single object_id.
+        Run an API query (Ad Insights or Ad Management) on a single object_id.
         """
         params = self.get_params()
 
         if self.ad_insights:
             data = self.query_ad_insights(self._api_fields, params, object_id)
         else:
-            data = self.query_object_node(self._api_fields, params, object_id)
+            data = self.query_ad_management(self._api_fields, params, object_id)
 
         yield from self.result_generator(data)
 
@@ -392,7 +443,6 @@ class FacebookReader(Reader):
 
     def read(self):
 
-        FacebookAdsApi.init(self.app_id, self.app_secret, self.access_token)
         yield NormalizedJSONStream(
             "results_" + self.object_type + "_" + "_".join(self.object_ids),
             self.get_data(),


### PR DESCRIPTION
### Issue

A lot of API calls are made during Ad Management queries.
Here is the process that we currently follow if we want to get configuration info on AdCreatives (for instance): 
- Step 1 - We get all AdCreative objects under the account (= 1 API call)
- Step 2 - For each AdCreative object, we make 1 API call to get the requested fields

It has 2 downsides:
- In terms of processing time, it is very slow.
- If we are not vigilant, API rate limit can be reached.

### Proposed enhancement

I implemented batch requests (of 50 items) to the Ad Management endpoint.
- With this set-up, Facebook API can parallelize requests, making our connector much more efficient (17 seconds for 1,000 requests vs. 1min30 previously).
- Also, it gives us access to response headers, allowing us to put the program on sleep if we are too close to the API rate limit.

### Additional changes

I also took advantage of this PR to implement more granular input checks (as we just did on the Twitter connector).

### Facebook documentation
- [Batch requests](https://developers.facebook.com/docs/graph-api/making-multiple-requests/)
- [Rate limiting](https://developers.facebook.com/docs/graph-api/overview/rate-limiting/)