### PR TITLE
Added flag to add viewId optionally

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 ipdb
+pytest
 flake8
 nose
 parameterized==0.7.1


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- Streams generated by the GA reader did not contain any informations about the requested view ID.

### Description

- Added a Click flag "--ga-add-view" to be able to add the requested view ID in each row of the stream. 

### Tests

- Added a test_format_data_and_view_id method to test the addition of the field "viewId" in the GaStream.
