### PR TITLE
Feat: add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,12 @@
 **/.env
 **/.flake8
 **/.gitignore
-**/CONTRIBUTING.md
-**/README.md
+**/.git
+CONTRIBUTING.md
+README.md
+**/__pycache__
+**/*.pyc
+**/.settings
+**/.vscode
+**/Dockerfile*
+**/requirements-dev.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/.github
+**/tests
+**/.env
+**/.flake8
+**/.gitignore
+**/CONTRIBUTING.md
+**/README.md


### PR DESCRIPTION
### Issue

fix #34 

### Description

Add `.dockerignore` in order to reduce image size and build time.

### Tests

No need for tests as there is no code linked to this PR.

### Documentation

This is not for end users and it does not impact contributions directly, so there is no documentation attached to this PR.