### PR TITLE
GoogleAds: skipping inactive clientCustomerIds

### DIFF
--- a/nck/readers/googleads_reader.py
+++ b/nck/readers/googleads_reader.py
@@ -192,7 +192,7 @@ class GoogleAdsReader(Reader):
                 return customer_report
             except AdWordsReportBadRequestError as e:
                 if e.type == "AuthorizationError.CUSTOMER_NOT_ACTIVE":
-                    logging.info(
+                    logging.warning(
                         f"Skipping clientCustomerId {client_customer_id} (inactive)."
                     )
                 else:


### PR DESCRIPTION
**Context**
If a GoogleAds account reaches 15 months without spend, it is cancelled (but your client can still reactivate it following Google guidelines on [this link](https://support.google.com/google-ads/answer/2375392?hl=en)). As a consequence, if you try to request a report from this account, the API call will raise an exception.

**Previous behavior**
If one of the GoogleAds accounts involved in the request is cancelled, the whole NCK command crashes.

**New behavior**
If one of the GoogleAds accounts involved in the request is cancelled, it is skipped and the NCK command continues to run.