### PR TITLE
 Integration Tests: Real world testing with Docker-Compose

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,11 @@
+FROM python:3.7
+
+ADD requirements* /nautilus-connectors-kit/
+
+WORKDIR /nautilus-connectors-kit
+
+RUN pip install -r requirements-dev.txt
+
+ADD . /nautilus-connectors-kit
+
+CMD [ "pytest", "tests/integration"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+    db:
+        image: mysql:latest
+        command: --default-authentication-plugin=mysql_native_password
+        environment: 
+            - MYSQL_USER=test
+            - MYSQL_PASSWORD=secret
+            - MYSQL_ROOT_PASSWORD=root-secret
+            - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+            - MYSQL_DATABASE=employees
+        ports: 
+            - "3306:3306"
+        volumes:
+            - ./tests/resources/employees.sql:/docker-entrypoint-initdb.d/employees.sql
+        container_name: nck_test_mysql_db
+        cap_add: 
+            - SYS_NICE
+    tests:
+        build:
+            context: .
+            dockerfile: Dockerfile.test
+        environment:
+           - MYSQL_DATABASE=employees
+           - MYSQL_HOST=db
+           - MYSQL_PORT=3306
+           - MYSQL_USER=test
+           - MYSQL_PASSWORD=secret
+           - PYTHONPATH=.
+        depends_on:
+            - db

--- a/nck/readers/sql_reader.py
+++ b/nck/readers/sql_reader.py
@@ -122,7 +122,7 @@ class SQLReader(Reader):
             )
         else:
             self._query = build_custom_query(
-                self._engine, schema, query, watermark_column, self._watermark_value
+                self._engine, query, watermark_column, self._watermark_value
             )
 
     @staticmethod

--- a/tests/integration/test_mysql_reader.py
+++ b/tests/integration/test_mysql_reader.py
@@ -1,0 +1,34 @@
+import os
+from nck.readers.mysql_reader import MySQLReader
+
+
+class TestMySQlReader:
+
+    # using tests/resources/employees.sql database
+
+    basic_query = "SELECT * FROM firstname"
+
+    # +---------+
+    # | myfield |
+    # +---------+
+    # | Pierre  |
+    # | Julien  |
+    # +---------+
+
+    sql_env = {
+        "user" : os.environ["MYSQL_USER"],
+        "password" : os.environ["MYSQL_PASSWORD"],
+        "host" : os.environ["MYSQL_HOST"],
+        "port": os.environ["MYSQL_PORT"],
+        "database" : os.environ["MYSQL_DATABASE"]
+    }
+
+    sql_env["query"] = basic_query
+
+    mySQLReader = MySQLReader(**sql_env)
+
+    def test_one(self):
+        # MySQLReader.read() returns a generator object we need to extract
+        json_stream = list(self.mySQLReader.read())
+        request_result = list(json_stream[0].readlines())
+        assert request_result == [{'myfield': 'Pierre'}, {'myfield': 'Julien'}]

--- a/tests/resources/employees.sql
+++ b/tests/resources/employees.sql
@@ -1,0 +1,7 @@
+USE employees;
+
+GRANT ALL ON employees.* TO 'test';
+
+CREATE TABLE firstname (myfield VARCHAR(20));
+
+INSERT INTO firstname VALUES ('Pierre'), ('Julien');


### PR DESCRIPTION
WIP: DO NOT MERGE.

I thought It was a good idea to start writing some integration tests for nck.
Docker-compose seems to be a good tool to address this effort.

Doing a `docker-compose up` will launch a container that embeds a mysql db populated of small testing data and call the tests located at /tests/integration/ in a separate container.

Writing the very first test, I've noticed we can't instantiate a MySQL reader in any way, neither calling its class functions 
because of a NotImplementedError.

In fact, both the init method and the _create_engine class method are relying on the following code.
 ` @staticmethod
    def connector_adaptor():
        raise NotImplementedError`


Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following Issue (If an issue exists in JIRA or Github)

### Description

- [ ] Here are some details about my PR, including example of usage.

### Tests

- [x] My PR add the s the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does