### PR TITLE
fix: remove commented code and unused variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@
 
 from setuptools import setup, find_packages
 
-with open('README.md') as readme_file:
-    readme = readme_file.read()
 
 with open('requirements.txt') as requirements_file:
     requirements = [el.strip() for el in requirements_file.readlines()]
@@ -47,9 +45,7 @@ setup(
         ],
     },
     install_requires=requirements,
-    #  long_description=readme + '\n\n' + history,
     include_package_data=True,
-    # keywords='nautilus_connectors',
     name='nck',
     packages=find_packages(),
     setup_requires=setup_requirements,


### PR DESCRIPTION
### Issue

Build failed. See the [logs](https://github.com/artefactory/nautilus-connectors-kit/runs/1057021760).

### Description

The README file was needed in order to get package documentation. As NCK is mostly used as a Docker image, this documentation is not useful. It is already in the README.