### PR TITLE
fix: better output file name with gsheet reader

### DIFF
--- a/nck/readers/gs_reader.py
+++ b/nck/readers/gs_reader.py
@@ -128,4 +128,4 @@ class GSheetsReader(Reader):
             for record in list_of_hashes:
                 yield record
 
-        yield JSONStream(sheet, result_generator())
+        yield JSONStream("gsheet", result_generator())


### PR DESCRIPTION
### Issue

Gsheet reader output file did not have a meaningful name and contained whitespaces that might cause errors.

### Description

Change first part of the name with _gsheet_