### PR TITLE
upgrade facebook-business to v8.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ curlify==2.2.1
 cx-Oracle==7.3.0
 docopt==0.6.2
 docutils==0.15.2
-facebook-business==5.0.2
+facebook-business==8.0.4
 google-api-core==1.14.3
 google-api-python-client==1.4.2
 google-auth==1.7.2


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- Facebook Business API v5.0 deprecated: API calls don't work since 2020-09-28