### PR TITLE
Feat: adding Confluence Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Nautilus connectors kit is a tool which aim is getting raw data from different s
 - Adobe Analytics 1.4
 - Adobe Analytics 2.0
 - Amazon S3
+- Confluence
 - Facebook Marketing
 - Google Ads
 - Google Analytics

--- a/nck/helpers/confluence_helper.py
+++ b/nck/helpers/confluence_helper.py
@@ -151,6 +151,12 @@ CUSTOM_FIELDS = {
         "format_function_kwargs": {"key": "id"},
         "formatted_object_type": str,
     },
+    "children_page_title": {
+        "source_field": "children.page.results",
+        "format_function": _get_key_values_from_list_of_dct,
+        "format_function_kwargs": {"key": "title"},
+        "formatted_object_type": str,
+    },
     "client_properties": {
         "source_field": "body.storage.value",
         "format_function": _get_client_properties,

--- a/nck/helpers/confluence_helper.py
+++ b/nck/helpers/confluence_helper.py
@@ -1,0 +1,192 @@
+from bs4 import BeautifulSoup
+from unidecode import unidecode
+import re
+
+
+def parse_response(raw_response, fields):
+    for content_dct in raw_response["results"]:
+        content_record = {}
+        for field in fields:
+            field_path = _get_field_path(field)
+            field_value = _get_field_value(content_dct, field_path)
+            field_as_dct = _format_field_as_dct(field, field_value)
+            content_record.update(field_as_dct)
+        yield content_record
+
+
+# PARSE RESPONSE: Helpers
+
+def _get_field_path(field):
+    if field in CUSTOM_FIELDS:
+        return CUSTOM_FIELDS[field]["source_field"].split(".")
+    else:
+        return field.split(".")
+
+
+def _get_field_value(content_dct, field_path, visited=[]):
+    path_item = field_path[0]
+    remaining_path_items = len(field_path) - 1
+    visited.append(path_item)
+    if path_item in content_dct:
+        if remaining_path_items == 0:
+            return content_dct[path_item]
+        else:
+            return _get_field_value(content_dct[path_item], field_path[1:], visited)
+
+
+def _format_field_as_dct(field, field_value):
+    if field not in CUSTOM_FIELDS:
+        field_as_dct = {field: field_value}
+    else:
+        format_function = CUSTOM_FIELDS[field]["format_function"]
+        kwargs = CUSTOM_FIELDS[field]["format_function_kwargs"]
+        formatted_object = format_function(field_value, **kwargs)
+        if CUSTOM_FIELDS[field]["formatted_object_type"] == dict:
+            field_as_dct = formatted_object
+        else:
+            field_as_dct = {field: formatted_object}
+    return {_decode(key): _decode(value) for key, value in field_as_dct.items()}
+
+
+def _decode(raw_value):
+    if isinstance(raw_value, str):
+        decoded_emoji = raw_value.encode("utf-16", "surrogatepass").decode("utf-16")
+        return unidecode(decoded_emoji).replace("  ", " ").strip()
+    else:
+        return raw_value
+
+
+# CUSTOM FIELDS: format functions
+
+def _get_tiny_link(field_value):
+    atlassian_domain = field_value["self"].split("/wiki")[0]
+    shortened_path = field_value["tinyui"]
+    return f"{atlassian_domain}/wiki{shortened_path}"
+
+
+def _get_key_values_from_list_of_dct(list_of_dct, key):
+    key_values = [dct.get(key, "") for dct in list_of_dct]
+    return "|".join(key_values)
+
+
+def _get_client_properties(field_value):
+    client_properties_dct = {}
+    html_soup = BeautifulSoup(field_value, "lxml")
+    DEFAULT_PROPERTIES = [
+        "CONFIDENTIALITY", "ARTICLE STATUS", "INDUSTRY", "CLIENT COMPANY", "SCOPE",
+        "MISSION START DATE", "MISSION END DATE", "AMOUNT SOLD", "MISSION TOPIC",
+        "COMMERCIAL PROPOSAL", "ONE PAGER", "ARCHITECTURE"
+    ]
+
+    properties_section = _get_section_by_title(html_soup, "CASE ID CARD")
+    if properties_section is not None:
+
+        table = properties_section.table
+        rows = table.find_all("tr")
+
+        first_row_headers = rows[0].find_all("th")
+        first_row_datas = rows[0].find_all("td")
+        if len(first_row_headers) == 1 and len(first_row_datas) == 1:
+
+            for row in rows:
+
+                key = _decode(row.th.text).upper()
+                text = _decode(row.td.text)
+                links = [elt["href"] for elt in row.find_all("a")]
+
+                if key in ["COMMERCIAL PROPOSAL", "ONE PAGER", "ARCHITECTURE"]:
+                    client_properties_dct[key] = "|".join(links)
+                elif key in ["CONFIDENTIALITY", "ARTICLE STATUS"]:
+                    client_properties_dct[key] = re.sub(r"Green|Yellow|Red", "", text).upper()
+                else:
+                    client_properties_dct[key] = text
+
+    return _clean_dct(client_properties_dct, DEFAULT_PROPERTIES, "", "client_property_")
+
+
+def _get_client_completion(field_value):
+    client_completion_dct = {}
+    html_soup = BeautifulSoup(field_value, "lxml")
+    DEFAULT_SECTIONS_LENGTH = {"KEY LEARNINGS": 195, "CONTEXT": 117, "APPROACH": 232, "CONCLUSION": 83}
+
+    for required_title in DEFAULT_SECTIONS_LENGTH:
+        section = _get_section_by_title(html_soup, required_title)
+        if section is not None:
+            text = _decode(section.text)
+            section_is_completed = (len(text) > DEFAULT_SECTIONS_LENGTH[required_title])
+            client_completion_dct[required_title] = int(section_is_completed)
+
+    return _clean_dct(client_completion_dct, DEFAULT_SECTIONS_LENGTH.keys(), 0, "client_completion_")
+
+
+CUSTOM_FIELDS = {
+    "tiny_link": {
+        "source_field": "_links",
+        "format_function": _get_tiny_link,
+        "format_function_kwargs": {},
+        "formatted_object_type": str
+    },
+    "label_names": {
+        "source_field": "metadata.labels.results",
+        "format_function": _get_key_values_from_list_of_dct,
+        "format_function_kwargs": {"key": "name"},
+        "formatted_object_type": str
+    },
+    "children_page_titles": {
+        "source_field": "children.page.results",
+        "format_function": _get_key_values_from_list_of_dct,
+        "format_function_kwargs": {"key": "title"},
+        "formatted_object_type": str
+    },
+    "client_properties": {
+        "source_field": "body.storage.value",
+        "format_function": _get_client_properties,
+        "format_function_kwargs": {},
+        "formatted_object_type": dict,
+        "specific_to_spacekeys": ["KA"]
+    },
+    "client_completion": {
+        "source_field": "body.storage.value",
+        "format_function": _get_client_completion,
+        "format_function_kwargs": {},
+        "formatted_object_type": dict,
+        "specific_to_spacekeys": ["KA"]
+    }
+}
+
+
+# CUSTOM FIELDS: helpers
+
+def _get_section_by_title(html_soup, searched_title):
+    for section in html_soup.find_all("ac:layout-section"):
+
+        h1_elements = [_decode(h1.text).upper() for h1 in section.find_all("h1")]
+        strong_elements = [_decode(strong.text).upper() for strong in section.find_all("strong")]
+        section_titles = list(set(h1_elements + strong_elements))
+
+        for title in section_titles:
+            if searched_title in title:
+                return section
+
+
+def _clean_dct(dct, expected_keys, default_value, prefix):
+    cleaned_dct = _remove_optional_keys(dct, expected_keys)
+    cleaned_dct = _add_missing_keys(cleaned_dct, expected_keys, default_value)
+    cleaned_dct = _add_prefix(cleaned_dct, prefix)
+    return cleaned_dct
+
+
+def _remove_optional_keys(dct, expected_keys):
+    return {key: value for key, value in dct.items() if key in expected_keys}
+
+
+def _add_missing_keys(dct, expected_keys, default_value):
+    missing_keys = expected_keys - dct.keys()
+    if len(missing_keys) > 0:
+        for key in missing_keys:
+            dct[key] = default_value
+    return dct
+
+
+def _add_prefix(dct, prefix):
+    return {f"{prefix}{key}": value for key, value in dct.items()}

--- a/nck/helpers/confluence_helper.py
+++ b/nck/helpers/confluence_helper.py
@@ -145,10 +145,10 @@ CUSTOM_FIELDS = {
         "format_function_kwargs": {"key": "name"},
         "formatted_object_type": str,
     },
-    "children_page_titles": {
+    "children_page_id": {
         "source_field": "children.page.results",
         "format_function": _get_key_values_from_list_of_dct,
-        "format_function_kwargs": {"key": "title"},
+        "format_function_kwargs": {"key": "id"},
         "formatted_object_type": str,
     },
     "client_properties": {

--- a/nck/helpers/confluence_helper.py
+++ b/nck/helpers/confluence_helper.py
@@ -114,7 +114,7 @@ def _get_client_properties(field_value: str) -> Optional[Dict[str, str]]:
                 else:
                     client_properties_dct[key] = text
 
-    return DictToClean(client_properties_dct, DEFAULT_PROPERTIES, 0, "client_property_").clean()
+    return DictToClean(client_properties_dct, DEFAULT_PROPERTIES, "", "client_property_").clean()
 
 
 def _get_client_completion(field_value: str) -> Optional[Dict[str, int]]:
@@ -129,7 +129,7 @@ def _get_client_completion(field_value: str) -> Optional[Dict[str, int]]:
             section_is_completed = len(text) > DEFAULT_SECTIONS_LENGTH[required_title]
             client_completion_dct[required_title] = int(section_is_completed)
 
-    return DictToClean(client_completion_dct, DEFAULT_SECTIONS_LENGTH.keys(), "", "client_completion_").clean()
+    return DictToClean(client_completion_dct, DEFAULT_SECTIONS_LENGTH.keys(), 0, "client_completion_").clean()
 
 
 CUSTOM_FIELDS = {

--- a/nck/readers/__init__.py
+++ b/nck/readers/__init__.py
@@ -39,6 +39,7 @@ from nck.readers.radarly_reader import radarly
 from nck.readers.yandex_campaign_reader import yandex_campaigns
 from nck.readers.yandex_statistics_reader import yandex_statistics
 from nck.readers.gs_reader import google_sheets
+from nck.readers.confluence_reader import confluence
 
 readers = [
     mysql,
@@ -62,7 +63,8 @@ readers = [
     radarly,
     yandex_campaigns,
     yandex_statistics,
-    google_sheets
+    google_sheets,
+    confluence
 ]
 
 

--- a/nck/readers/__init__.py
+++ b/nck/readers/__init__.py
@@ -64,7 +64,7 @@ readers = [
     yandex_campaigns,
     yandex_statistics,
     google_sheets,
-    confluence
+    confluence,
 ]
 
 

--- a/nck/readers/confluence_reader.py
+++ b/nck/readers/confluence_reader.py
@@ -1,0 +1,174 @@
+# GNU Lesser General Public License v3.0 only
+# Copyright (C) 2020 Artefact
+# licence-information@artefact.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import base64
+import requests
+from itertools import chain
+import click
+from click import ClickException
+
+from nck.utils.args import extract_args
+from nck.commands.command import processor
+from nck.readers.reader import Reader
+from nck.helpers.confluence_helper import parse_response, CUSTOM_FIELDS
+from nck.streams.json_stream import JSONStream
+from nck.streams.normalized_json_stream import NormalizedJSONStream
+
+RECORDS_PER_PAGE = 100
+CONTENT_ENDPOINT = "wiki/rest/api/content"
+
+
+@click.command(name="read_confluence")
+@click.option(
+    "--confluence-user-login",
+    required=True,
+    help="User login associated with your Atlassian account"
+)
+@click.option(
+    "--confluence-api-token",
+    required=True,
+    help="API token associated with your Atlassian account"
+)
+@click.option(
+    "--confluence-atlassian-domain",
+    required=True,
+    help="Atlassian domain under which the content to request is located"
+)
+@click.option(
+    "--confluence-content-type",
+    type=click.Choice(["page", "blogpost"]),
+    default="page",
+    help="Type of content on which the report should be filtered"
+)
+@click.option(
+    "--confluence-spacekey",
+    multiple=True,
+    help="Space keys on which the report should be filtered"
+)
+@click.option(
+    "--confluence-field",
+    required=True,
+    multiple=True,
+    help="Fields that should be included in the report (path.to.field.value or custom_field)"
+)
+@click.option(
+    "--confluence-normalize-stream",
+    type=click.BOOL,
+    default=False,
+    help="If set to True, yields a NormalizedJSONStream (spaces and special "
+    "characters replaced by '_' in field names, which is useful for BigQuery). "
+    "Else, yields a standard JSONStream."
+)
+@processor("confluence_user_login", "confluence_api_token")
+def confluence(**kwargs):
+    return ConfluenceReader(**extract_args("confluence_", kwargs))
+
+
+class ConfluenceReader(Reader):
+
+    def __init__(
+        self,
+        user_login,
+        api_token,
+        atlassian_domain,
+        content_type,
+        spacekey,
+        field,
+        normalize_stream
+    ):
+        self.user_login = user_login
+        self.api_token = api_token
+        self.build_headers()
+        self.atlassian_domain = atlassian_domain
+        self.content_type = content_type
+        self.spacekeys = list(spacekey)
+        self.fields = list(field)
+        self.normalize_stream = normalize_stream
+
+        self.validate_spacekeys()
+
+    def validate_spacekeys(self):
+        requirements = [
+            CUSTOM_FIELDS[field]["specific_to_spacekeys"] for field in self.fields
+            if field in CUSTOM_FIELDS and "specific_to_spacekeys" in CUSTOM_FIELDS[field]
+        ]
+        if len(requirements) > 0:
+            inter_requirements = (
+                requirements[0] if len(requirements) == 1
+                else list(set(requirements[0]).intersection(*requirements[1:]))
+            )
+            if len(inter_requirements) == 0:
+                raise ClickException("Invalid request. No intersection found between spacekey requirements.")
+            elif self.spacekeys != inter_requirements:
+                raise ClickException(f"Invalid request. Spacekeys should be set to '{inter_requirements}'.")
+
+    def build_headers(self):
+        api_login = f"{self.user_login}:{self.api_token}"
+        encoded_bytes = base64.b64encode(api_login.encode("utf-8"))
+        encoded_string = str(encoded_bytes, "utf-8")
+        self.headers = {
+            "Authorization": f"Basic {encoded_string}",
+            "Content-Type": "application/json"
+        }
+
+    def build_params(self):
+        api_fields = [
+            CUSTOM_FIELDS[field]["source_field"]
+            if field in CUSTOM_FIELDS
+            else field for field in self.fields
+        ]
+        return {"type": self.content_type, "expand": ",".join(api_fields)}
+
+    def get_raw_response(self, page_nb, spacekey=None):
+        params = self.build_params()
+        params["start"] = page_nb * RECORDS_PER_PAGE
+        params["limit"] = RECORDS_PER_PAGE
+        if spacekey is not None:
+            params["spaceKey"] = spacekey
+
+        url = f"{self.atlassian_domain}/{CONTENT_ENDPOINT}"
+        response = requests.get(url, headers=self.headers, params=params)
+        if response.ok:
+            return response.json()
+        else:
+            response.raise_for_status()
+
+    def get_report_generator(self, spacekey=None):
+        page_nb = 0
+        raw_response = self.get_raw_response(page_nb, spacekey)
+        all_responses = [parse_response(raw_response, self.fields)]
+
+        while raw_response["_links"].get("next"):
+            page_nb += 1
+            raw_response = self.get_raw_response(page_nb, spacekey)
+            all_responses.append(parse_response(raw_response, self.fields))
+
+        return chain(*all_responses)
+
+    def get_aggregated_report_generator(self):
+        if self.spacekeys:
+            for spacekey in self.spacekeys:
+                yield from self.get_report_generator(spacekey)
+        else:
+            yield from self.get_report_generator()
+
+    def read(self):
+        if self.normalize_stream:
+            yield NormalizedJSONStream("results_", self.get_aggregated_report_generator())
+        else:
+            yield JSONStream("results_", self.get_aggregated_report_generator())

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,4 +64,4 @@ googleads==22.0.0
 twitter-ads==7.0.1
 pyjwt==1.7.1
 cryptography==2.9
-bs4==4.9.1
+bs4==0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,3 +64,4 @@ googleads==22.0.0
 twitter-ads==7.0.1
 pyjwt==1.7.1
 cryptography==2.9
+bs4==4.9.1

--- a/tests/helpers/test_confluence_helper.py
+++ b/tests/helpers/test_confluence_helper.py
@@ -39,7 +39,7 @@ CONTENT_DCT = {
     "space": {"name": "How To Guides"},
     "metadata": {"labels": {"results": [{"name": "nck"}, {"name": "api"}]}},
     "_links": {"self": "https://your-domain.com/wiki/rest/api/content/00001", "tinyui": "/x/aBcD"},
-    "body": {"storage": {"value": HTML_BODY}}
+    "body": {"storage": {"value": HTML_BODY}},
 }
 
 EXPECTED_CLIENT_PROPERTIES = {
@@ -54,41 +54,39 @@ EXPECTED_CLIENT_PROPERTIES = {
     "client_property_MISSION TOPIC": "Precision Marketing",
     "client_property_COMMERCIAL PROPOSAL": "https://commercial_proposal.com",
     "client_property_ONE PAGER": "https://one_pager.com",
-    "client_property_ARCHITECTURE": "https://architecture.com"
+    "client_property_ARCHITECTURE": "https://architecture.com",
 }
 
 EXPECTED_CLIENT_COMPLETION = {
     "client_completion_KEY LEARNINGS": 1,
     "client_completion_CONTEXT": 1,
     "client_completion_APPROACH": 0,
-    "client_completion_CONCLUSION": 1
+    "client_completion_CONCLUSION": 1,
 }
 
 
 class CustomFieldsTest(TestCase):
-
     def test__get_tiny_link(self):
         from nck.helpers.confluence_helper import _get_tiny_link
+
         field_value = {"self": "https://your-domain.com/wiki/rest/api/content/00001", "tinyui": "/x/aBcD"}
         expected = "https://your-domain.com/wiki/x/aBcD"
         self.assertEqual(_get_tiny_link(field_value), expected)
 
-    @parameterized.expand(
-        [
-            ([{"name": "nck"}, {"name": "api"}], "name", "nck|api"),
-            ([], "name", "")
-        ]
-    )
+    @parameterized.expand([([{"name": "nck"}, {"name": "api"}], "name", "nck|api"), ([], "name", "")])
     def test__get_key_values_from_list_of_dct(self, field_value, key, expected):
         from nck.helpers.confluence_helper import _get_key_values_from_list_of_dct
+
         self.assertEqual(_get_key_values_from_list_of_dct(field_value, key), expected)
 
     def test__get_client_properties(self):
         from nck.helpers.confluence_helper import _get_client_properties
+
         self.assertDictEqual(_get_client_properties(HTML_BODY), EXPECTED_CLIENT_PROPERTIES)
 
     def test__get_client_completion(self):
         from nck.helpers.confluence_helper import _get_client_completion
+
         self.assertDictEqual(_get_client_completion(HTML_BODY), EXPECTED_CLIENT_COMPLETION)
 
     @parameterized.expand(
@@ -98,19 +96,20 @@ class CustomFieldsTest(TestCase):
                     "<ac:layout-section><h1>II. Approach</h1><p>In data we trust.</p></ac:layout-section>"
                     "<ac:layout-section><h1>Team</h1><p>B. Gates, M. Zuckerberg</p></ac:layout-section>"
                 ),
-                "<ac:layout-section><h1>II. Approach</h1><p>In data we trust.</p></ac:layout-section>"
+                "<ac:layout-section><h1>II. Approach</h1><p>In data we trust.</p></ac:layout-section>",
             ),
             (
                 (
                     "<ac:layout-section><strong>II. Approach</strong><p>In data we trust.</p></ac:layout-section>"
                     "<ac:layout-section><h1>Team</h1><p>B. Gates, M. Zuckerberg</p></ac:layout-section>"
                 ),
-                "<ac:layout-section><strong>II. Approach</strong><p>In data we trust.</p></ac:layout-section>"
-            )
+                "<ac:layout-section><strong>II. Approach</strong><p>In data we trust.</p></ac:layout-section>",
+            ),
         ]
     )
     def test__get_section_by_title(self, html_body, expected):
         from nck.helpers.confluence_helper import _get_section_by_title
+
         searched_title = "APPROACH"
         html_soup = BeautifulSoup(html_body, "lxml")
         output = _get_section_by_title(html_soup, searched_title)
@@ -118,6 +117,7 @@ class CustomFieldsTest(TestCase):
 
     def test__clean_dct(self):
         from nck.helpers.confluence_helper import _clean_dct
+
         dct = {"CLIENT COMPANY": "Michelin", "SCOPE": "France", "TEAM_SIZE": 10}
         expected_keys = ["CLIENT COMPANY", "SCOPE", "AMOUNT SOLD"]
         default_value = ""
@@ -127,16 +127,12 @@ class CustomFieldsTest(TestCase):
 
 
 class ParseResponseTest(TestCase):
-
     @parameterized.expand(
-        [
-            ("title", ["title"]),
-            ("space.name", ["space", "name"]),
-            ("label_names", ["metadata", "labels", "results"]),
-        ]
+        [("title", ["title"]), ("space.name", ["space", "name"]), ("label_names", ["metadata", "labels", "results"])]
     )
     def test__get_field_path(self, field, expected):
         from nck.helpers.confluence_helper import _get_field_path
+
         self.assertListEqual(_get_field_path(field), expected)
 
     @parameterized.expand(
@@ -144,50 +140,52 @@ class ParseResponseTest(TestCase):
             (["title"], "Making API requests with NCK"),
             (["space", "name"], "How To Guides"),
             (["metadata", "labels"], {"results": [{"name": "nck"}, {"name": "api"}]}),
-            (["invalid_key"], None)
+            (["invalid_key"], None),
         ]
     )
     def test__get_field_value(self, field_path, expected):
         from nck.helpers.confluence_helper import _get_field_value
+
         self.assertEqual(_get_field_value(CONTENT_DCT, field_path), expected)
 
     @parameterized.expand(
         [
             ("title", "Making API requests with NCK", {"title": "Making API requests with NCK"}),
             ("space.name", "How To Guides", {"space.name": "How To Guides"}),
-            ("label_names", [{"name": "nck"}, {"name": "api"}], {"label_names": "nck|api"})
+            ("label_names", [{"name": "nck"}, {"name": "api"}], {"label_names": "nck|api"}),
         ]
     )
     def test__format_field_as_dct(self, field, field_value, expected):
         from nck.helpers.confluence_helper import _format_field_as_dct
+
         self.assertDictEqual(_format_field_as_dct(field, field_value), expected)
 
     def test__parse_response(self):
         from nck.helpers.confluence_helper import parse_response
+
         raw_response = {
-            "results":
-            [
+            "results": [
                 {
                     "id": "00001",
                     "type": "page",
                     "title": "Making API requests with NCK",
                     "space": {"name": "How To Guides"},
-                    "metadata": {"labels": {"results": [{"name": "nck"}, {"name": "api"}]}}
+                    "metadata": {"labels": {"results": [{"name": "nck"}, {"name": "api"}]}},
                 },
                 {
                     "id": "00002",
                     "type": "page",
                     "title": "Writting a Client Case",
                     "space": {"name": "How To Guides"},
-                    "metadata": {"labels": {"results": [{"name": "confluence"}]}}
+                    "metadata": {"labels": {"results": [{"name": "confluence"}]}},
                 },
                 {
                     "id": "00003",
                     "type": "page",
                     "title": "Developping with Github",
                     "space": {"name": "How To Guides"},
-                    "metadata": {"labels": {"results": [{"name": "git"}]}}
-                }
+                    "metadata": {"labels": {"results": [{"name": "git"}]}},
+                },
             ]
         }
         fields = ["title", "space.name", "label_names"]
@@ -200,12 +198,8 @@ class ParseResponseTest(TestCase):
         for output_record, expected_record in zip(iter(output), iter(expected)):
             self.assertDictEqual(output_record, expected_record)
 
-    @parameterized.expand(
-        [
-            (u"\u2705 Title with \ud83d\udd36 emoji \ud83d\udd34", "Title with emoji"),
-            (0, 0)
-        ]
-    )
+    @parameterized.expand([("\u2705 Title with \ud83d\udd36 emoji \ud83d\udd34", "Title with emoji"), (0, 0)])
     def test__decode(self, raw_value, expected):
         from nck.helpers.confluence_helper import _decode
+
         self.assertEqual(_decode(raw_value), expected)

--- a/tests/helpers/test_confluence_helper.py
+++ b/tests/helpers/test_confluence_helper.py
@@ -115,15 +115,19 @@ class CustomFieldsTest(TestCase):
         output = _get_section_by_title(html_soup, searched_title)
         self.assertEqual(str(output), expected)
 
-    def test__clean_dct(self):
-        from nck.helpers.confluence_helper import _clean_dct
 
-        dct = {"CLIENT COMPANY": "Michelin", "SCOPE": "France", "TEAM_SIZE": 10}
-        expected_keys = ["CLIENT COMPANY", "SCOPE", "AMOUNT SOLD"]
+class DictToCleanTest(TestCase):
+    def test__clean(self):
+        from nck.helpers.confluence_helper import DictToClean
+
+        dct = {"CLIENT COMPANY": "Michelin", "SCOPE": "France", "TEAM SIZE": 10}
+        expected_keys = ["CLIENT COMPANY", "AMOUNT SOLD", "SCOPE"]
         default_value = ""
         prefix = "prefix_"
-        expected = {"prefix_CLIENT COMPANY": "Michelin", "prefix_SCOPE": "France", "prefix_AMOUNT SOLD": ""}
-        self.assertDictEqual(_clean_dct(dct, expected_keys, default_value, prefix), expected)
+
+        expected = {"prefix_CLIENT COMPANY": "Michelin", "prefix_AMOUNT SOLD": "", "prefix_SCOPE": "France"}
+        output = DictToClean(dct, expected_keys, default_value, prefix).clean()
+        self.assertDictEqual(output, expected)
 
 
 class ParseResponseTest(TestCase):

--- a/tests/helpers/test_confluence_helper.py
+++ b/tests/helpers/test_confluence_helper.py
@@ -1,0 +1,211 @@
+from unittest import TestCase
+from parameterized import parameterized
+from bs4 import BeautifulSoup
+
+PARAGRAPH_OF_200_CHARACTERS = (
+    "Lorem ipsum sit amet cursus sit amet dictum sit amet justo donec"
+    "enim diam vulputate ut pharetra sit amet aliquam id diam maecenas"
+    "ultricies mi eget mauris pharetra et ultrices neque ornare aenean felis"
+)
+
+HTML_BODY = (
+    "<ac:layout-section>"
+    "<h1>Case ID card</h1>"
+    "<table>"
+    "<tr><th>Confidentiality</th><td>GreenPublic</td></tr>"
+    "<tr><th>Article status</th><td>YellowIn progress</td></tr>"
+    "<tr><th>Industry</th><td>Automotive</td></tr>"
+    "<tr><th>Client company</th><td>Michelin</td></tr>"
+    "<tr><th>Scope</th><td>France</td></tr>"
+    "<tr><th>Mission start date</th><td>2020/01/01</td></tr>"
+    "<tr><th>Mission end date</th><td>8 weeks</td></tr>"
+    "<tr><th>Amount sold</th><td>45 KEUR</td></tr>"
+    "<tr><th>Mission topic</th><td>Precision Marketing</td></tr>"
+    "<tr><th>Commercial proposal</th><td><a href='https://commercial_proposal.com'>Click here</a></td></tr>"
+    "<tr><th>One pager</th><td><a href='https://one_pager.com'>Click here</a></td></tr>"
+    "<tr><th>Architecture</th><td><a href='https://architecture.com'>Click here</a></td></tr>"
+    "</table>"
+    "</ac:layout-section>"
+    f"<ac:layout-section><h1>Key learnings</h1><p>{PARAGRAPH_OF_200_CHARACTERS}</p></ac:layout-section>"
+    f"<ac:layout-section><h1>I. Context</h1><p>{PARAGRAPH_OF_200_CHARACTERS}</p></ac:layout-section>"
+    f"<ac:layout-section><h1>II. Approach</h1><p>{PARAGRAPH_OF_200_CHARACTERS}</p></ac:layout-section>"
+    f"<ac:layout-section><h1>III. Conclusion</h1><p>{PARAGRAPH_OF_200_CHARACTERS}</p></ac:layout-section>"
+)
+
+CONTENT_DCT = {
+    "id": "00001",
+    "type": "page",
+    "title": "Making API requests with NCK",
+    "space": {"name": "How To Guides"},
+    "metadata": {"labels": {"results": [{"name": "nck"}, {"name": "api"}]}},
+    "_links": {"self": "https://your-domain.com/wiki/rest/api/content/00001", "tinyui": "/x/aBcD"},
+    "body": {"storage": {"value": HTML_BODY}}
+}
+
+EXPECTED_CLIENT_PROPERTIES = {
+    "client_property_CONFIDENTIALITY": "PUBLIC",
+    "client_property_ARTICLE STATUS": "IN PROGRESS",
+    "client_property_INDUSTRY": "Automotive",
+    "client_property_CLIENT COMPANY": "Michelin",
+    "client_property_SCOPE": "France",
+    "client_property_MISSION START DATE": "2020/01/01",
+    "client_property_MISSION END DATE": "8 weeks",
+    "client_property_AMOUNT SOLD": "45 KEUR",
+    "client_property_MISSION TOPIC": "Precision Marketing",
+    "client_property_COMMERCIAL PROPOSAL": "https://commercial_proposal.com",
+    "client_property_ONE PAGER": "https://one_pager.com",
+    "client_property_ARCHITECTURE": "https://architecture.com"
+}
+
+EXPECTED_CLIENT_COMPLETION = {
+    "client_completion_KEY LEARNINGS": 1,
+    "client_completion_CONTEXT": 1,
+    "client_completion_APPROACH": 0,
+    "client_completion_CONCLUSION": 1
+}
+
+
+class CustomFieldsTest(TestCase):
+
+    def test__get_tiny_link(self):
+        from nck.helpers.confluence_helper import _get_tiny_link
+        field_value = {"self": "https://your-domain.com/wiki/rest/api/content/00001", "tinyui": "/x/aBcD"}
+        expected = "https://your-domain.com/wiki/x/aBcD"
+        self.assertEqual(_get_tiny_link(field_value), expected)
+
+    @parameterized.expand(
+        [
+            ([{"name": "nck"}, {"name": "api"}], "name", "nck|api"),
+            ([], "name", "")
+        ]
+    )
+    def test__get_key_values_from_list_of_dct(self, field_value, key, expected):
+        from nck.helpers.confluence_helper import _get_key_values_from_list_of_dct
+        self.assertEqual(_get_key_values_from_list_of_dct(field_value, key), expected)
+
+    def test__get_client_properties(self):
+        from nck.helpers.confluence_helper import _get_client_properties
+        self.assertDictEqual(_get_client_properties(HTML_BODY), EXPECTED_CLIENT_PROPERTIES)
+
+    def test__get_client_completion(self):
+        from nck.helpers.confluence_helper import _get_client_completion
+        self.assertDictEqual(_get_client_completion(HTML_BODY), EXPECTED_CLIENT_COMPLETION)
+
+    @parameterized.expand(
+        [
+            (
+                (
+                    "<ac:layout-section><h1>II. Approach</h1><p>In data we trust.</p></ac:layout-section>"
+                    "<ac:layout-section><h1>Team</h1><p>B. Gates, M. Zuckerberg</p></ac:layout-section>"
+                ),
+                "<ac:layout-section><h1>II. Approach</h1><p>In data we trust.</p></ac:layout-section>"
+            ),
+            (
+                (
+                    "<ac:layout-section><strong>II. Approach</strong><p>In data we trust.</p></ac:layout-section>"
+                    "<ac:layout-section><h1>Team</h1><p>B. Gates, M. Zuckerberg</p></ac:layout-section>"
+                ),
+                "<ac:layout-section><strong>II. Approach</strong><p>In data we trust.</p></ac:layout-section>"
+            )
+        ]
+    )
+    def test__get_section_by_title(self, html_body, expected):
+        from nck.helpers.confluence_helper import _get_section_by_title
+        searched_title = "APPROACH"
+        html_soup = BeautifulSoup(html_body, "lxml")
+        output = _get_section_by_title(html_soup, searched_title)
+        self.assertEqual(str(output), expected)
+
+    def test__clean_dct(self):
+        from nck.helpers.confluence_helper import _clean_dct
+        dct = {"CLIENT COMPANY": "Michelin", "SCOPE": "France", "TEAM_SIZE": 10}
+        expected_keys = ["CLIENT COMPANY", "SCOPE", "AMOUNT SOLD"]
+        default_value = ""
+        prefix = "prefix_"
+        expected = {"prefix_CLIENT COMPANY": "Michelin", "prefix_SCOPE": "France", "prefix_AMOUNT SOLD": ""}
+        self.assertDictEqual(_clean_dct(dct, expected_keys, default_value, prefix), expected)
+
+
+class ParseResponseTest(TestCase):
+
+    @parameterized.expand(
+        [
+            ("title", ["title"]),
+            ("space.name", ["space", "name"]),
+            ("label_names", ["metadata", "labels", "results"]),
+        ]
+    )
+    def test__get_field_path(self, field, expected):
+        from nck.helpers.confluence_helper import _get_field_path
+        self.assertListEqual(_get_field_path(field), expected)
+
+    @parameterized.expand(
+        [
+            (["title"], "Making API requests with NCK"),
+            (["space", "name"], "How To Guides"),
+            (["metadata", "labels"], {"results": [{"name": "nck"}, {"name": "api"}]}),
+            (["invalid_key"], None)
+        ]
+    )
+    def test__get_field_value(self, field_path, expected):
+        from nck.helpers.confluence_helper import _get_field_value
+        self.assertEqual(_get_field_value(CONTENT_DCT, field_path), expected)
+
+    @parameterized.expand(
+        [
+            ("title", "Making API requests with NCK", {"title": "Making API requests with NCK"}),
+            ("space.name", "How To Guides", {"space.name": "How To Guides"}),
+            ("label_names", [{"name": "nck"}, {"name": "api"}], {"label_names": "nck|api"})
+        ]
+    )
+    def test__format_field_as_dct(self, field, field_value, expected):
+        from nck.helpers.confluence_helper import _format_field_as_dct
+        self.assertDictEqual(_format_field_as_dct(field, field_value), expected)
+
+    def test__parse_response(self):
+        from nck.helpers.confluence_helper import parse_response
+        raw_response = {
+            "results":
+            [
+                {
+                    "id": "00001",
+                    "type": "page",
+                    "title": "Making API requests with NCK",
+                    "space": {"name": "How To Guides"},
+                    "metadata": {"labels": {"results": [{"name": "nck"}, {"name": "api"}]}}
+                },
+                {
+                    "id": "00002",
+                    "type": "page",
+                    "title": "Writting a Client Case",
+                    "space": {"name": "How To Guides"},
+                    "metadata": {"labels": {"results": [{"name": "confluence"}]}}
+                },
+                {
+                    "id": "00003",
+                    "type": "page",
+                    "title": "Developping with Github",
+                    "space": {"name": "How To Guides"},
+                    "metadata": {"labels": {"results": [{"name": "git"}]}}
+                }
+            ]
+        }
+        fields = ["title", "space.name", "label_names"]
+        expected = [
+            {"title": "Making API requests with NCK", "space.name": "How To Guides", "label_names": "nck|api"},
+            {"title": "Writting a Client Case", "space.name": "How To Guides", "label_names": "confluence"},
+            {"title": "Developping with Github", "space.name": "How To Guides", "label_names": "git"},
+        ]
+        output = parse_response(raw_response, fields)
+        for output_record, expected_record in zip(iter(output), iter(expected)):
+            self.assertDictEqual(output_record, expected_record)
+
+    @parameterized.expand(
+        [
+            (u"\u2705 Title with \ud83d\udd36 emoji \ud83d\udd34", "Title with emoji"),
+            (0, 0)
+        ]
+    )
+    def test__decode(self, raw_value, expected):
+        from nck.helpers.confluence_helper import _decode
+        self.assertEqual(_decode(raw_value), expected)

--- a/tests/readers/test_confluence_reader.py
+++ b/tests/readers/test_confluence_reader.py
@@ -96,28 +96,28 @@ class ConfluenceReaderTest(TestCase):
         self.assertDictEqual(output, expected)
 
     def test__build_params(self):
-        output = ConfluenceReader(**self.kwargs).build_params()
+        output = ConfluenceReader(**self.kwargs)._build_params()
         expected = {"type": "page", "expand": "title,space.name,metadata.labels.results"}
         self.assertDictEqual(output, expected)
 
     @mock.patch.object(
-        ConfluenceReader, "get_raw_response", side_effect=[KEY1_RAW_RESPONSE_PAGE0, KEY1_RAW_RESPONSE_PAGE1]
+        ConfluenceReader, "_get_raw_response", side_effect=[KEY1_RAW_RESPONSE_PAGE0, KEY1_RAW_RESPONSE_PAGE1]
     )
     def test__get_report_generator(self, mock_get_raw_response):
         temp_kwargs = self.kwargs.copy()
         temp_kwargs.update({"spacekey": ["KEY1"]})
-        output = ConfluenceReader(**self.kwargs).get_report_generator()
+        output = ConfluenceReader(**self.kwargs)._get_report_generator()
         expected = iter(KEY1_FINAL_RECORDS)
         for output_record, expected_record in zip(output, expected):
             self.assertEqual(output_record, expected_record)
 
     @mock.patch.object(
-        ConfluenceReader, "get_report_generator", side_effect=[iter(KEY1_FINAL_RECORDS), iter(KEY2_FINAL_RECORDS)]
+        ConfluenceReader, "_get_report_generator", side_effect=[iter(KEY1_FINAL_RECORDS), iter(KEY2_FINAL_RECORDS)]
     )
     def test__get_aggregated_report_generator(self, mock_get_report_generator):
         temp_kwargs = self.kwargs.copy()
         temp_kwargs.update({"spacekey": ["KEY1", "KEY2"]})
-        output = ConfluenceReader(**self.kwargs).get_aggregated_report_generator()
+        output = ConfluenceReader(**self.kwargs)._get_aggregated_report_generator()
         expected = iter(KEY1_FINAL_RECORDS + KEY2_FINAL_RECORDS)
         for output_record, expected_record in zip(output, expected):
             self.assertEqual(output_record, expected_record)

--- a/tests/readers/test_confluence_reader.py
+++ b/tests/readers/test_confluence_reader.py
@@ -1,0 +1,129 @@
+# GNU Lesser General Public License v3.0 only
+# Copyright (C) 2020 Artefact
+# licence-information@artefact.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from unittest import TestCase, mock
+from click import ClickException
+
+from nck.readers.confluence_reader import ConfluenceReader
+
+KEY1_RAW_RESPONSE_PAGE0 = {
+    "results":
+    [
+        {
+            "title": "Making API requests with NCK",
+            "space": {"name": "How To Guides"},
+            "metadata": {"labels": {"results": [{"name": "api"}]}}
+        },
+        {
+            "title": "Writting a Client Case",
+            "space": {"name": "How To Guides"},
+            "metadata": {"labels": {"results": [{"name": "confluence"}]}}
+        }
+    ],
+    "_links": {"next": "link_to_next_request_page"}
+}
+
+KEY1_RAW_RESPONSE_PAGE1 = {
+    "results":
+    [
+        {
+            "title": "Developping with Github",
+            "space": {"name": "How To Guides"},
+            "metadata": {"labels": {"results": [{"name": "git"}]}}
+        }
+    ],
+    "_links": {}
+}
+
+KEY1_FINAL_RECORDS = [
+    {"title": "Making API requests with NCK", "space.name": "How To Guides", "label_names": "api"},
+    {"title": "Writting a Client Case", "space.name": "How To Guides", "label_names": "confluence"},
+    {"title": "Developping with Github", "space.name": "How To Guides", "label_names": "git"}
+]
+
+KEY2_FINAL_RECORDS = [
+    {"title": "Samsung - Precision Marketing", "space.name": "Clients", "label_names": "pm"},
+    {"title": "P&G - Demand Sensing", "space.name": "Clients", "label_names": "ai"},
+    {"title": "Orange - Call center automation", "space.name": "Clients", "label_names": "ai"},
+]
+
+
+class ConfluenceReaderTest(TestCase):
+
+    kwargs = {
+        "user_login": "firstname.name@your-domain.com",
+        "api_token": "aAbBcCdDeE12fFgGhHiIjJ34",
+        "atlassian_domain": "https://your-domain.com",
+        "content_type": "page",
+        "spacekey": [],
+        "field": ["title", "space.name", "label_names"],
+        "normalize_stream": False
+    }
+
+    @mock.patch(
+        "nck.readers.confluence_reader.CUSTOM_FIELDS",
+        {
+            "custom_field_A": {"specific_to_spacekeys": ["KEY1"]},
+            "custom_field_B": {"specific_to_spacekeys": ["KEY1", "KEY2"]},
+            "custom_field_C": {}
+        }
+    )
+    def test__validate_spacekeys(self):
+        temp_kwargs = self.kwargs.copy()
+        temp_kwargs.update({"field": ["custom_field_A", "custom_field_B", "custom_field_C"]})
+        with self.assertRaises(ClickException):
+            ConfluenceReader(**temp_kwargs)
+
+    def test__build_headers(self):
+        output = ConfluenceReader(**self.kwargs).headers
+        expected = {
+            "Authorization": "Basic Zmlyc3RuYW1lLm5hbWVAeW91ci1kb21haW4uY29tOmFBYkJjQ2REZUUxMmZGZ0doSGlJakozNA==",
+            "Content-Type": "application/json"
+        }
+        self.assertDictEqual(output, expected)
+
+    def test__build_params(self):
+        output = ConfluenceReader(**self.kwargs).build_params()
+        expected = {"type": "page", "expand": "title,space.name,metadata.labels.results"}
+        self.assertDictEqual(output, expected)
+
+    @mock.patch.object(
+        ConfluenceReader,
+        "get_raw_response",
+        side_effect=[KEY1_RAW_RESPONSE_PAGE0, KEY1_RAW_RESPONSE_PAGE1]
+    )
+    def test__get_report_generator(self, mock_get_raw_response):
+        temp_kwargs = self.kwargs.copy()
+        temp_kwargs.update({"spacekey": ["KEY1"]})
+        output = ConfluenceReader(**self.kwargs).get_report_generator()
+        expected = iter(KEY1_FINAL_RECORDS)
+        for output_record, expected_record in zip(output, expected):
+            self.assertEqual(output_record, expected_record)
+
+    @mock.patch.object(
+        ConfluenceReader,
+        "get_report_generator",
+        side_effect=[iter(KEY1_FINAL_RECORDS), iter(KEY2_FINAL_RECORDS)]
+    )
+    def test__get_aggregated_report_generator(self, mock_get_report_generator):
+        temp_kwargs = self.kwargs.copy()
+        temp_kwargs.update({"spacekey": ["KEY1", "KEY2"]})
+        output = ConfluenceReader(**self.kwargs).get_aggregated_report_generator()
+        expected = iter(KEY1_FINAL_RECORDS + KEY2_FINAL_RECORDS)
+        for output_record, expected_record in zip(output, expected):
+            self.assertEqual(output_record, expected_record)

--- a/tests/readers/test_confluence_reader.py
+++ b/tests/readers/test_confluence_reader.py
@@ -22,38 +22,36 @@ from click import ClickException
 from nck.readers.confluence_reader import ConfluenceReader
 
 KEY1_RAW_RESPONSE_PAGE0 = {
-    "results":
-    [
+    "results": [
         {
             "title": "Making API requests with NCK",
             "space": {"name": "How To Guides"},
-            "metadata": {"labels": {"results": [{"name": "api"}]}}
+            "metadata": {"labels": {"results": [{"name": "api"}]}},
         },
         {
             "title": "Writting a Client Case",
             "space": {"name": "How To Guides"},
-            "metadata": {"labels": {"results": [{"name": "confluence"}]}}
-        }
+            "metadata": {"labels": {"results": [{"name": "confluence"}]}},
+        },
     ],
-    "_links": {"next": "link_to_next_request_page"}
+    "_links": {"next": "link_to_next_request_page"},
 }
 
 KEY1_RAW_RESPONSE_PAGE1 = {
-    "results":
-    [
+    "results": [
         {
             "title": "Developping with Github",
             "space": {"name": "How To Guides"},
-            "metadata": {"labels": {"results": [{"name": "git"}]}}
+            "metadata": {"labels": {"results": [{"name": "git"}]}},
         }
     ],
-    "_links": {}
+    "_links": {},
 }
 
 KEY1_FINAL_RECORDS = [
     {"title": "Making API requests with NCK", "space.name": "How To Guides", "label_names": "api"},
     {"title": "Writting a Client Case", "space.name": "How To Guides", "label_names": "confluence"},
-    {"title": "Developping with Github", "space.name": "How To Guides", "label_names": "git"}
+    {"title": "Developping with Github", "space.name": "How To Guides", "label_names": "git"},
 ]
 
 KEY2_FINAL_RECORDS = [
@@ -72,7 +70,7 @@ class ConfluenceReaderTest(TestCase):
         "content_type": "page",
         "spacekey": [],
         "field": ["title", "space.name", "label_names"],
-        "normalize_stream": False
+        "normalize_stream": False,
     }
 
     @mock.patch(
@@ -80,8 +78,8 @@ class ConfluenceReaderTest(TestCase):
         {
             "custom_field_A": {"specific_to_spacekeys": ["KEY1"]},
             "custom_field_B": {"specific_to_spacekeys": ["KEY1", "KEY2"]},
-            "custom_field_C": {}
-        }
+            "custom_field_C": {},
+        },
     )
     def test__validate_spacekeys(self):
         temp_kwargs = self.kwargs.copy()
@@ -93,7 +91,7 @@ class ConfluenceReaderTest(TestCase):
         output = ConfluenceReader(**self.kwargs).headers
         expected = {
             "Authorization": "Basic Zmlyc3RuYW1lLm5hbWVAeW91ci1kb21haW4uY29tOmFBYkJjQ2REZUUxMmZGZ0doSGlJakozNA==",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
         self.assertDictEqual(output, expected)
 
@@ -103,9 +101,7 @@ class ConfluenceReaderTest(TestCase):
         self.assertDictEqual(output, expected)
 
     @mock.patch.object(
-        ConfluenceReader,
-        "get_raw_response",
-        side_effect=[KEY1_RAW_RESPONSE_PAGE0, KEY1_RAW_RESPONSE_PAGE1]
+        ConfluenceReader, "get_raw_response", side_effect=[KEY1_RAW_RESPONSE_PAGE0, KEY1_RAW_RESPONSE_PAGE1]
     )
     def test__get_report_generator(self, mock_get_raw_response):
         temp_kwargs = self.kwargs.copy()
@@ -116,9 +112,7 @@ class ConfluenceReaderTest(TestCase):
             self.assertEqual(output_record, expected_record)
 
     @mock.patch.object(
-        ConfluenceReader,
-        "get_report_generator",
-        side_effect=[iter(KEY1_FINAL_RECORDS), iter(KEY2_FINAL_RECORDS)]
+        ConfluenceReader, "get_report_generator", side_effect=[iter(KEY1_FINAL_RECORDS), iter(KEY2_FINAL_RECORDS)]
     )
     def test__get_aggregated_report_generator(self, mock_get_report_generator):
         temp_kwargs = self.kwargs.copy()


### PR DESCRIPTION
### Description

- Adding **a new Confluence Reader** (requested by Benoit Robin). The primary purpose of this connector is to get an overview of the pages available on Smartefact (title, link, associated labels, etc.).
- To meet Benoit's needs, I had to **create custom fields that are parsing the HTML body of Smartefact pages** (for instance, the `client_completion` field checks if mandatory template sections have been filled by users or not). It makes API response parsing a bit more complex than usually, but I tried to make it as smooth as possible.

### Tests

This PR adds tests.

### Documentation

This PR adds documentation.