### PR TITLE
Fix/Enh: a few fixes/enhancements to the Facebook reader

### DIFF
--- a/nck/helpers/facebook_helper.py
+++ b/nck/helpers/facebook_helper.py
@@ -85,6 +85,16 @@ def obj_follows_action_breakdown_pattern(obj):
     )
 
 
+def obj_is_list_of_single_values(obj):
+    """
+    Checks wether obj is a list of strings, integers or floats.
+    """
+    return (
+        isinstance(obj, list)
+        and all(isinstance(elt, (str, int, float)) for elt in obj)
+    )
+
+
 def obj_meets_action_breakdown_filters(obj, filters):
     """
     Checks if a nested action breakdown object
@@ -166,6 +176,8 @@ def get_field_values(resp_obj, field_path, action_breakdowns, visited=[]):
         if remaining_path_items == 0:
             if obj_follows_action_breakdown_pattern(current_obj):
                 return get_all_action_breakdown_values(current_obj, visited, action_breakdowns)
+            elif obj_is_list_of_single_values(current_obj):
+                return {format_field_path(visited): ", ".join(map(str, current_obj))}
             else:
                 return {format_field_path(visited): str(current_obj)}
         else:

--- a/nck/helpers/facebook_helper.py
+++ b/nck/helpers/facebook_helper.py
@@ -22,7 +22,7 @@ from time import sleep
 
 from facebook_business.adobjects.adsinsights import AdsInsights
 
-FACEBOOK_OBJECTS = ["creative", "ad", "adset", "campaign", "account"]
+FACEBOOK_OBJECTS = ["pixel", "creative", "ad", "adset", "campaign", "account"]
 
 DATE_PRESETS = [
     v for k, v in AdsInsights.DatePreset.__dict__.items() if not k.startswith("__")

--- a/nck/readers/README.md
+++ b/nck/readers/README.md
@@ -156,9 +156,9 @@ Didn't work? See [troubleshooting](#troubleshooting) section.
 |`--facebook-app-id`|Facebook App ID. *Not mandatory if Facebook Access Token is provided.*|
 |`--facebook-app-secret`|Facebook App Secret. *Not mandatory if Facebook Access Token is provided.*|
 |`--facebook-access-token`|Facebook App Access Token.|
-|`--facebook-object-type`|Nature of the root Facebook Object used to make the request. *Possible values: creative (available only for Ad Management requests), ad, adset, campaign, account (default).*|
+|`--facebook-object-type`|Nature of the root Facebook Object used to make the request. *Possible values: pixel (Ad Management requests only), creative (Ad Management requests only), ad, adset, campaign, account (default).*|
 |`--facebook-object-id`|ID of the root Facebook Object used to make the request.|
-|`--facebook-level`|Granularity of the response. *Possible values: creative (available only for Ad Management requests), ad (default), adset, campaign, account.*|
+|`--facebook-level`|Granularity of the response. *Possible values: pixel (Ad Management requests only), creative (Ad Management requests only), ad (default), adset, campaign, account.*|
 |`--facebook-ad-insights`|*True* (default) if *Ad Insights* request, *False* if *Ad Management* request.|
 |`--facebook-field`|Fields to be retrieved.|
 |`--facebook-start-date`|Start date of the period to request (format: YYYY-MM-DD). *This parameter is only relevant for Ad Insights Requests, and Ad Management requests at the Campaign, Adset and Ad levels.*|
@@ -175,18 +175,19 @@ Didn't work? See [troubleshooting](#troubleshooting) section.
 
 |If Facebook Object Type is...|Facebook Level can be...|
 |:--|:--|
-|`account`|account, campaign, adset, ad, creative|
+|`account`|account, campaign, adset, ad, creative, pixel|
 |`campaign`|campaign, adset, ad|
 |`adset`|adset, ad, creative|
 |`ad`|ad, creative|
 |`creative`|creative|
+|`pixel`|pixel|
 
 **2. Format Facebook Marketing Reader response using `--facebook-fields`**
 
 2.1. The list of **applicable fields** can be found on the links below:
 
 - **Ad Insights Request**: [all fields](https://developers.facebook.com/docs/marketing-api/insights/parameters/v7.0)
-- **Ad Management Request**: [Account-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-account), [Campaign-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group), [Adset-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign), [Ad-level fields](https://developers.facebook.com/docs/marketing-api/reference/adgroup), [Creative-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-creative)
+- **Ad Management Request**: [Account-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-account), [Campaign-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group), [Adset-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign), [Ad-level fields](https://developers.facebook.com/docs/marketing-api/reference/adgroup), [Creative-level fields](https://developers.facebook.com/docs/marketing-api/reference/ad-creative), [Pixel-level fields](https://developers.facebook.com/docs/marketing-api/reference/ads-pixel/)
 
 2.2. If you want to select **a nested field value**,  simply indicate the path to this value within the request field.
 

--- a/nck/readers/facebook_reader.py
+++ b/nck/readers/facebook_reader.py
@@ -44,6 +44,7 @@ from facebook_business.adobjects.campaign import Campaign
 from facebook_business.adobjects.adset import AdSet
 from facebook_business.adobjects.ad import Ad
 from facebook_business.adobjects.adcreative import AdCreative
+from facebook_business.adobjects.adspixel import AdsPixel
 
 DATEFORMAT = "%Y-%m-%d"
 
@@ -53,13 +54,14 @@ OBJECT_CREATION_MAPPING = {
     "adset": AdSet,
     "ad": Ad,
     "creative": AdCreative,
+    "pixel": AdsPixel
 }
 
 EDGE_MAPPING = {
-    "account": ["campaign", "adset", "ad", "creative"],
+    "account": ["campaign", "adset", "ad", "creative", "pixel"],
     "campaign": ["adset", "ad"],
     "adset": ["ad", "creative"],
-    "ad": ["creative"],
+    "ad": ["creative"]
 }
 
 EDGE_QUERY_MAPPING = {
@@ -67,6 +69,7 @@ EDGE_QUERY_MAPPING = {
     "adset": lambda obj: obj.get_ad_sets(),
     "ad": lambda obj: obj.get_ads(),
     "creative": lambda obj: obj.get_ad_creatives(),
+    "pixel": lambda obj: obj.get_ads_pixels()
 }
 
 BATCH_SIZE_LIMIT = 50

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ curlify==2.2.1
 cx-Oracle==7.3.0
 docopt==0.6.2
 docutils==0.15.2
-facebook-business==5.0.2
+facebook-business==8.0.5
 google-api-core==1.14.3
 google-api-python-client==1.4.2
 google-auth==1.7.2

--- a/tests/helpers/test_api_client_helper.py
+++ b/tests/helpers/test_api_client_helper.py
@@ -48,7 +48,7 @@ class ApiClientHelperTest(unittest.TestCase):
         ("t_e_s_t", "TEST")
     ])
     def test_to_pascal_key(self, key, pascal_key):
-        self.assertEquals(to_pascal_key(key), pascal_key)
+        self.assertEqual(to_pascal_key(key), pascal_key)
 
     def test_unknown_case(self):
         with self.assertLogs() as cm:

--- a/tests/readers/test_facebook_reader.py
+++ b/tests/readers/test_facebook_reader.py
@@ -275,3 +275,29 @@ class FacebookReaderTest(TestCase):
         self.assertEqual(
             next(FacebookReader(**temp_kwargs).format_and_yield(record)), expected
         )
+
+    @parameterized.expand(
+        [
+            (
+                "simple_list_of_dicts",
+                [
+                    {"event": "CLICK_THROUGH", "days": 28},
+                    {"event": "VIEW_THROUGH", "days": 1}
+                ],
+                False
+            ),
+            (
+                "action_breakdown_list_of_dicts",
+                [
+                    {"action_type": "link_click", "action_device": "iphone", "value": "0"},
+                    {"action_type": "post_engagement", "action_device": "iphone", "value": "1"}
+                ],
+                True
+            )
+        ]
+    )
+    def test_obj_follows_action_breakdown_pattern(self, name, obj, expected):
+        from nck.helpers.facebook_helper import obj_follows_action_breakdown_pattern
+
+        output = obj_follows_action_breakdown_pattern(obj)
+        self.assertEqual(output, expected)

--- a/tests/readers/test_facebook_reader.py
+++ b/tests/readers/test_facebook_reader.py
@@ -252,18 +252,20 @@ class FacebookReaderTest(TestCase):
             ),
             (
                 "various_field_formats",
-                {"field": ["f_string", "f_numeric", "f_python_obj", "f_facebook_obj"]},
+                {"field": ["f_string", "f_numeric", "f_list_of_single_values", "f_python_obj", "f_facebook_obj"]},
                 {
-                    "f_string": "Artefact",
+                    "f_string": "CAMPAIGN_PAUSED",
                     "f_numeric": 10.95,
-                    "f_python_obj": [{"event": "CLICK_THROUGH", "days": 28}, {"event": "VIEW_THROUGH", "days": 1}],
-                    "f_facebook_obj": mock_facebook_obj({"id": "123456789", "display_name": "my_object_name"})
+                    "f_list_of_single_values": ["CAMPAIGN_PAUSED", 1, 10.95],
+                    "f_python_obj": [{'event': 'CLICK_THROUGH', 'days': 28}, {'event': 'VIEW_THROUGH', 'days': 1}],
+                    "f_facebook_obj": mock_facebook_obj({'id': '123456789', 'display_name': 'my_object_name'})
                 },
                 {
-                    "f_string": str("Artefact"),
-                    "f_numeric": str(10.95),
-                    "f_python_obj": str([{"event": "CLICK_THROUGH", "days": 28}, {"event": "VIEW_THROUGH", "days": 1}]),
-                    "f_facebook_obj": str({"id": "123456789", "display_name": "my_object_name"})
+                    "f_string": "CAMPAIGN_PAUSED",
+                    "f_numeric": "10.95",
+                    "f_list_of_single_values": "CAMPAIGN_PAUSED, 1, 10.95",
+                    "f_python_obj": "[{'event': 'CLICK_THROUGH', 'days': 28}, {'event': 'VIEW_THROUGH', 'days': 1}]",
+                    "f_facebook_obj": "{'id': '123456789', 'display_name': 'my_object_name'}"
                 }
             )
         ]
@@ -300,4 +302,24 @@ class FacebookReaderTest(TestCase):
         from nck.helpers.facebook_helper import obj_follows_action_breakdown_pattern
 
         output = obj_follows_action_breakdown_pattern(obj)
+        self.assertEqual(output, expected)
+
+    @parameterized.expand(
+        [
+            (
+                "list_of_dicts",
+                [{"event": "CLICK_THROUGH", "days": 28}, {"event": "VIEW_THROUGH", "days": 1}],
+                False
+            ),
+            (
+                "list_of_single_values",
+                ["CAMPAIGN_PAUSED", 1, 10.95],
+                True
+            ),
+        ]
+    )
+    def test_obj_is_list_of_single_values(self, name, obj, expected):
+        from nck.helpers.facebook_helper import obj_is_list_of_single_values
+
+        output = obj_is_list_of_single_values(obj)
         self.assertEqual(output, expected)

--- a/tests/readers/test_facebook_reader.py
+++ b/tests/readers/test_facebook_reader.py
@@ -244,6 +244,22 @@ class FacebookReaderTest(TestCase):
                 {"impressions": "1"},
                 {"impressions": "1"},
             ),
+            (
+                "various_field_formats",
+                {"field": ["string_field", "int_field", "float_field", "list_of_strings_field"]},
+                {
+                    "string_field": "Artefact",
+                    "int_field": 1,
+                    "float_field": 10.95,
+                    "list_of_strings_field": ["STRING_1", "STRING_2"]
+                },
+                {
+                    "string_field": "Artefact",
+                    "int_field": "1",
+                    "float_field": "10.95",
+                    "list_of_strings_field": "STRING_1|STRING_2"
+                }
+            )
         ]
     )
     @mock.patch.object(FacebookAdsApi, "init", lambda *args: None)

--- a/tests/readers/test_facebook_reader.py
+++ b/tests/readers/test_facebook_reader.py
@@ -27,6 +27,12 @@ from facebook_business.adobjects.adsinsights import AdsInsights
 from facebook_business.adobjects.ad import Ad
 
 
+def mock_facebook_obj(data):
+    mocked_facebook_obj = mock.MagicMock()
+    mocked_facebook_obj._data = data
+    return mocked_facebook_obj
+
+
 class FacebookReaderTest(TestCase):
 
     DATEFORMAT = "%Y-%m-%d"
@@ -246,18 +252,18 @@ class FacebookReaderTest(TestCase):
             ),
             (
                 "various_field_formats",
-                {"field": ["string_field", "int_field", "float_field", "list_of_strings_field"]},
+                {"field": ["f_string", "f_numeric", "f_python_obj", "f_facebook_obj"]},
                 {
-                    "string_field": "Artefact",
-                    "int_field": 1,
-                    "float_field": 10.95,
-                    "list_of_strings_field": ["STRING_1", "STRING_2"]
+                    "f_string": "Artefact",
+                    "f_numeric": 10.95,
+                    "f_python_obj": [{"event": "CLICK_THROUGH", "days": 28}, {"event": "VIEW_THROUGH", "days": 1}],
+                    "f_facebook_obj": mock_facebook_obj({"id": "123456789", "display_name": "my_object_name"})
                 },
                 {
-                    "string_field": "Artefact",
-                    "int_field": "1",
-                    "float_field": "10.95",
-                    "list_of_strings_field": "STRING_1|STRING_2"
+                    "f_string": str("Artefact"),
+                    "f_numeric": str(10.95),
+                    "f_python_obj": str([{"event": "CLICK_THROUGH", "days": 28}, {"event": "VIEW_THROUGH", "days": 1}]),
+                    "f_facebook_obj": str({"id": "123456789", "display_name": "my_object_name"})
                 }
             )
         ]

--- a/tests/readers/test_yandex_statistics_reader.py
+++ b/tests/readers/test_yandex_statistics_reader.py
@@ -284,4 +284,4 @@ class TestYandexStatisticsReader(unittest.TestCase):
         )
         with self.assertRaises(click.ClickException) as click_exception:
             reader._add_custom_dates_if_set()
-        self.assertEquals(click_exception.exception.message, error_message_expected)
+        self.assertEqual(click_exception.exception.message, error_message_expected)


### PR DESCRIPTION
_All below updates are backward-compatible._

### Fixes

- **[Solved]** If a field value was not a string, if was not returned by the Facebook reader
- **[Solved]** If a field value was a list dictionaries, but not following an action breakdown pattern (= at least one key in each dictionary starts with "action_"), it made the Facebook reader crash

### Enhancements
- The Facebook reader now handles the Pixel level for Ad Management queries.
- The Facebook reader now allows you to explore fields content: the API call can be completed, even if you don't know exactly what the field values you're requesting look like (if they are strings, dictionaries, lists of dictionaries, Facebook objects, etc.). The Facebook reader will simply return the "raw" field value as a string, so that you can adjust your query.

Illustration

API response
```
{
     "object_story_spec": {
          "call_to_action": "LEARN_MORE",
          "link": "https://www.artefact.com"
     }
}
```

Facebook reader response
- If you request the "object_story_spec" field (= exploration):
```
{"object_story_spec": "{'call_to_action': 'LEARN_MORE', 'link': 'https://www.artefact.com'}"}
```
_Before, this call would have returned nothing, making the exploration quite complex (you had to adjust the Facebook reader code to print raw API responses in your terminal, and understand what was going on). Now it's much more intuitive, and it does not "break" the .njson file structure (you can still upload the output file to BQ: it doesn't crash)._
- If you request the "object_story_spec[call_to_action]" field (= query adjustement, as you only need this value):
```
{"object_story_spec_call_to_action": "LEARN_MORE"}
```
