### PR TITLE
Feat: add "Salesforce ID" to client properties

### DIFF
--- a/nck/helpers/confluence_helper.py
+++ b/nck/helpers/confluence_helper.py
@@ -77,6 +77,7 @@ def _get_client_properties(field_value: str) -> Optional[Dict[str, str]]:
     client_properties_dct = {}
     html_soup = BeautifulSoup(field_value, "lxml")
     DEFAULT_PROPERTIES = [
+        "SALESFORCE ID",
         "CONFIDENTIALITY",
         "ARTICLE STATUS",
         "INDUSTRY",

--- a/tests/helpers/test_confluence_helper.py
+++ b/tests/helpers/test_confluence_helper.py
@@ -12,6 +12,7 @@ HTML_BODY = (
     "<ac:layout-section>"
     "<h1>Case ID card</h1>"
     "<table>"
+    "<tr><th>Salesforce ID</th><td>0061t000003WEJ3AAO</td></tr>"
     "<tr><th>Confidentiality</th><td>GreenPublic</td></tr>"
     "<tr><th>Article status</th><td>YellowIn progress</td></tr>"
     "<tr><th>Industry</th><td>Automotive</td></tr>"
@@ -43,6 +44,7 @@ CONTENT_DCT = {
 }
 
 EXPECTED_CLIENT_PROPERTIES = {
+    "client_property_SALESFORCE ID": "0061t000003WEJ3AAO",
     "client_property_CONFIDENTIALITY": "PUBLIC",
     "client_property_ARTICLE STATUS": "IN PROGRESS",
     "client_property_INDUSTRY": "Automotive",


### PR DESCRIPTION
Minor enhancement.
Adding "Salesforce ID" to the list of client properties that should be collected from Client pages HTML body.