### PR TITLE
Feat/date range option for all readers

### DIFF
--- a/docs/source/readers.rst
+++ b/docs/source/readers.rst
@@ -128,7 +128,7 @@ Options                             Definition
 ``--adobe-2-0-metric``              Metric to include in the report
 ``--adobe-2-0-start-date``          Start date of the period to request (format: YYYY-MM-DD)
 ``--adobe-2-0-end-date``            Start date of the period to request (format: YYYY-MM-DD)
-``--adobe-2-0-date-range``          Date range. By default, not available in Adobe, so choose among NCK default values.
+``--adobe-2-0-date-range``          Date range. By default, not available in Adobe, so choose among NCK default values: YESTERDAY, LAST_7_DAYS, PREVIOUS_WEEK, PREVIOUS_MONTH, LAST_90_DAYS
 ==================================  =================================================================================================================================================================================
 
 ----------------------

--- a/docs/source/readers.rst
+++ b/docs/source/readers.rst
@@ -128,6 +128,7 @@ Options                             Definition
 ``--adobe-2-0-metric``              Metric to include in the report
 ``--adobe-2-0-start-date``          Start date of the period to request (format: YYYY-MM-DD)
 ``--adobe-2-0-end-date``            Start date of the period to request (format: YYYY-MM-DD)
+``--adobe-2-0-date-range``          Date range. By default, not available in Adobe, so choose among NCK default values.
 ==================================  =================================================================================================================================================================================
 
 ----------------------

--- a/nck/readers/adobe_reader_2_0.py
+++ b/nck/readers/adobe_reader_2_0.py
@@ -37,7 +37,7 @@ from nck.helpers.adobe_helper_2_0 import (
 from nck.readers.reader import Reader
 from nck.streams.json_stream import JSONStream
 from nck.utils.args import extract_args
-from nck.utils.date_handler import get_date_start_and_date_stop_from_date_range
+from nck.utils.date_handler import DEFAULT_DATE_RANGE_FUNCTIONS, get_date_start_and_date_stop_from_date_range
 from nck.utils.retry import retry
 
 DATEFORMAT = "%Y-%m-%dT%H:%M:%S"
@@ -120,9 +120,8 @@ def format_key_if_needed(ctx, param, value):
 )
 @click.option(
     "--adobe-2-0-date-range",
-    type=click.Choice(["LAST_7_DAYS", "YESTERDAY", "PREVIOUS_WEEK", "PREVIOUS_MONTH", "LAST_90_DAYS"]),
-    help="One of the available NCK default date ranges: YESTERDAY, LAST_7_DAYS, "
-    "PREVIOUS_WEEK, PREVIOUS_MONTH, LAST_90_DAYS",
+    type=click.Choice(DEFAULT_DATE_RANGE_FUNCTIONS.keys()),
+    help=f"One of the available NCK default date ranges: {DEFAULT_DATE_RANGE_FUNCTIONS.keys()}",
 )
 @processor(
     "adobe_2_0_client_id",

--- a/nck/readers/adobe_reader_2_0.py
+++ b/nck/readers/adobe_reader_2_0.py
@@ -16,27 +16,29 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import logging
-import click
 import json
-import requests
+import logging
 import time
-from itertools import chain
 from datetime import timedelta
+from itertools import chain
 
-from nck.utils.retry import retry
-from nck.utils.args import extract_args
-from nck.commands.command import processor
-from nck.readers.reader import Reader
+import click
+import requests
+from click.exceptions import ClickException
 from nck.clients.adobe_client import AdobeClient
-from nck.streams.json_stream import JSONStream
+from nck.commands.command import processor
 from nck.helpers.adobe_helper_2_0 import (
     APIRateLimitError,
     add_metric_container_to_report_description,
-    get_node_values_from_response,
     get_item_ids_from_nodes,
+    get_node_values_from_response,
     parse_response,
 )
+from nck.readers.reader import Reader
+from nck.streams.json_stream import JSONStream
+from nck.utils.args import extract_args
+from nck.utils.date_handler import get_date_start_and_date_stop_from_date_range
+from nck.utils.retry import retry
 
 DATEFORMAT = "%Y-%m-%dT%H:%M:%S"
 API_WINDOW_DURATION = 6
@@ -108,15 +110,19 @@ def format_key_if_needed(ctx, param, value):
 )
 @click.option(
     "--adobe-2-0-start-date",
-    required=True,
     type=click.DateTime(),
     help="Start date of the report",
 )
 @click.option(
     "--adobe-2-0-end-date",
-    required=True,
     type=click.DateTime(),
     help="End date of the report",
+)
+@click.option(
+    "--adobe-2-0-date-range",
+    type=click.Choice(["LAST_7_DAYS", "YESTERDAY", "PREVIOUS_WEEK", "PREVIOUS_MONTH", "LAST_90_DAYS"]),
+    help="One of the available NCK default date ranges: YESTERDAY, LAST_7_DAYS, "
+    "PREVIOUS_WEEK, PREVIOUS_MONTH, LAST_90_DAYS",
 )
 @processor(
     "adobe_2_0_client_id",
@@ -143,21 +149,30 @@ class AdobeReader_2_0(Reader):
         metric,
         start_date,
         end_date,
+        date_range,
     ):
-        self.adobe_client = AdobeClient(
-            client_id, client_secret, tech_account_id, org_id, private_key
-        )
+        self.adobe_client = AdobeClient(client_id, client_secret, tech_account_id, org_id, private_key)
         self.global_company_id = global_company_id
         self.report_suite_id = report_suite_id
         self.dimensions = list(dimension)
         self.metrics = list(metric)
         self.start_date = start_date
-        self.end_date = end_date + timedelta(days=1)
+        if end_date is not None:
+            self.end_date = end_date + timedelta(days=1)
+        else:
+            self.end_date = end_date
+        self.date_range = date_range
         self.ingestion_tracker = []
         self.node_values = {}
 
     def build_date_range(self):
-        return f"{self.start_date.strftime(DATEFORMAT)}/{self.end_date.strftime(DATEFORMAT)}"
+        if self.start_date is not None and self.end_date is not None and self.date_range is None:
+            return f"{self.start_date.strftime(DATEFORMAT)}/{self.end_date.strftime(DATEFORMAT)}"
+        elif self.start_date is None and self.end_date is None and self.date_range is not None:
+            start_date, end_date = get_date_start_and_date_stop_from_date_range(self.date_range)
+            return f"{start_date.strftime(DATEFORMAT)}/{(end_date + timedelta(days=1)).strftime(DATEFORMAT)}"
+        else:
+            raise ClickException("Dates are not defined properly. Please set start and end dates or a date range")
 
     def build_report_description(self, metrics, breakdown_item_ids=[]):
         """
@@ -169,9 +184,7 @@ class AdobeReader_2_0(Reader):
 
         rep_desc = {
             "rsid": self.report_suite_id,
-            "globalFilters": [
-                {"type": "dateRange", "dateRange": self.build_date_range()}
-            ],
+            "globalFilters": [{"type": "dateRange", "dateRange": self.build_date_range()}],
             "metricContainer": {},
             "dimension": f"variables/{self.dimensions[len(breakdown_item_ids)]}",
             "settings": {"countRepeatInstances": "true", "limit": "5000"},
@@ -193,19 +206,11 @@ class AdobeReader_2_0(Reader):
 
         current_time = time.time()
         self.ingestion_tracker.append(current_time)
-        window_ingestion_tracker = [
-            t
-            for t in self.ingestion_tracker
-            if t >= (current_time - API_WINDOW_DURATION)
-        ]
+        window_ingestion_tracker = [t for t in self.ingestion_tracker if t >= (current_time - API_WINDOW_DURATION)]
 
         if len(window_ingestion_tracker) >= API_REQUESTS_OVER_WINDOW_LIMIT:
-            sleep_time = (
-                window_ingestion_tracker[0] + API_WINDOW_DURATION - current_time
-            )
-            logging.warning(
-                f"Throttling activated: sleeping for {sleep_time} seconds..."
-            )
+            sleep_time = window_ingestion_tracker[0] + API_WINDOW_DURATION - current_time
+            logging.warning(f"Throttling activated: sleeping for {sleep_time} seconds...")
             time.sleep(sleep_time)
 
     @retry
@@ -251,9 +256,7 @@ class AdobeReader_2_0(Reader):
         if first_response["totalPages"] > 1:
             for page_nb in range(1, first_response["totalPages"]):
                 next_response = self.get_report_page(rep_desc, page_nb)
-                all_responses += [
-                    parse_response(next_response, metrics, parent_dim_parsed)
-                ]
+                all_responses += [parse_response(next_response, metrics, parent_dim_parsed)]
 
         return chain(*all_responses)
 
@@ -264,17 +267,13 @@ class AdobeReader_2_0(Reader):
         For instance: {'daterangeday_1200001': 'Jan 1, 2020'}
         """
 
-        rep_desc = self.build_report_description(
-            metrics=["visits"], breakdown_item_ids=breakdown_item_ids
-        )
+        rep_desc = self.build_report_description(metrics=["visits"], breakdown_item_ids=breakdown_item_ids)
         first_response = self.get_report_page(rep_desc)
         node_values = get_node_values_from_response(first_response)
 
         if first_response["totalPages"] > 1:
             for page_nb in range(1, first_response["totalPages"]):
-                next_node_values = get_node_values_from_response(
-                    self.get_report_page(rep_desc, page_nb)
-                )
+                next_node_values = get_node_values_from_response(self.get_report_page(rep_desc, page_nb))
                 node_values.update(next_node_values)
 
         return node_values
@@ -333,13 +332,9 @@ class AdobeReader_2_0(Reader):
 
             # If no remaining node children to explore: get report
             if len(path_to_node) == len(self.dimensions) - 1:
-                parent_dim_parsed = {
-                    node.split("_")[0]: self.node_values[node] for node in path_to_node
-                }
+                parent_dim_parsed = {node.split("_")[0]: self.node_values[node] for node in path_to_node}
                 breakdown_item_ids = get_item_ids_from_nodes(path_to_node)
-                rep_desc = self.build_report_description(
-                    self.metrics, breakdown_item_ids
-                )
+                rep_desc = self.build_report_description(self.metrics, breakdown_item_ids)
                 data = self.get_parsed_report(rep_desc, self.metrics, parent_dim_parsed)
                 yield from self.result_generator(data)
 
@@ -348,9 +343,7 @@ class AdobeReader_2_0(Reader):
             visited.append(node)
 
         # Update unvisited_childs
-        unvisited_childs = [
-            child_node for child_node in graph[node] if child_node not in visited
-        ]
+        unvisited_childs = [child_node for child_node in graph[node] if child_node not in visited]
 
         # Read through child node children
         for child_node in unvisited_childs:
@@ -366,10 +359,6 @@ class AdobeReader_2_0(Reader):
     def read(self):
 
         if len(self.dimensions) == 1:
-            yield JSONStream(
-                "results_" + self.report_suite_id, self.read_one_dimension()
-            )
+            yield JSONStream("results_" + self.report_suite_id, self.read_one_dimension())
         elif len(self.dimensions) > 1:
-            yield JSONStream(
-                "results_" + self.report_suite_id, self.read_through_graph()
-            )
+            yield JSONStream("results_" + self.report_suite_id, self.read_through_graph())

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -3,19 +3,40 @@ from datetime import date, timedelta
 from typing import Tuple
 
 
-def get_date_start_and_date_stop_from_range(
-    date_range: str
-) -> Tuple[date, date]:
-    today = date.today()
-    if date_range == "PREVIOUS_MONTH":
-        last_day_of_previous_month = \
-            today.replace(day=1) - timedelta(days=1)
-        year = last_day_of_previous_month.year
-        month = last_day_of_previous_month.month
-        return date(year, month, 1), date(year, month, calendar.monthrange(year, month)[1])
+def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date, date]:
+    current_date = date.today()
+    if date_range == "YESTERDAY":
+        return __get_yesterday_date(current_date)
+    elif date_range == "LAST_7_DAYS":
+        return __get_last_7d_dates(current_date)
+    elif date_range == "LAST_90_DAYS":
+        return __get_last_90d_dates(current_date)
     elif date_range == "PREVIOUS_WEEK":
-        # The API uses American standard, weeks go from sunday yo next saturday
-        first_day_of_last_week = today - timedelta(days=today.weekday() + 1, weeks=1)
-        return first_day_of_last_week, first_day_of_last_week + timedelta(days=6)
-    else:
-        return None
+        return __get_previous_week_dates(current_date)
+    elif date_range == "PREVIOUS_MONTH":
+        return __get_previous_month_dates(current_date)
+
+
+def __get_yesterday_date(current_date: date) -> Tuple[date, date]:
+    yesterday = current_date - timedelta(days=1)
+    return yesterday, yesterday
+
+
+def __get_last_7d_dates(current_date: date) -> Tuple[date, date]:
+    return current_date - timedelta(days=8), current_date - timedelta(days=1)
+
+
+def __get_last_90d_dates(current_date: date) -> Tuple[date, date]:
+    return current_date - timedelta(days=91), current_date - timedelta(days=1)
+
+
+def __get_previous_week_dates(current_date: date) -> Tuple[date, date]:
+    first_day_of_last_week = current_date - timedelta(days=current_date.weekday(), weeks=1)
+    return first_day_of_last_week, first_day_of_last_week + timedelta(days=6)
+
+
+def __get_previous_month_dates(current_date: date) -> Tuple[date, date]:
+    last_day_of_previous_month = current_date.replace(day=1) - timedelta(days=1)
+    year = last_day_of_previous_month.year
+    month = last_day_of_previous_month.month
+    return date(year, month, 1), date(year, month, calendar.monthrange(year, month)[1])

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -3,20 +3,6 @@ from datetime import date, timedelta
 from typing import Tuple
 
 
-def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date, date]:
-    current_date = date.today()
-    if date_range == "YESTERDAY":
-        return __get_yesterday_date(current_date)
-    elif date_range == "LAST_7_DAYS":
-        return __get_last_7d_dates(current_date)
-    elif date_range == "LAST_90_DAYS":
-        return __get_last_90d_dates(current_date)
-    elif date_range == "PREVIOUS_WEEK":
-        return __get_previous_week_dates(current_date)
-    elif date_range == "PREVIOUS_MONTH":
-        return __get_previous_month_dates(current_date)
-
-
 def __get_yesterday_date(current_date: date) -> Tuple[date, date]:
     yesterday = current_date - timedelta(days=1)
     return yesterday, yesterday
@@ -40,3 +26,17 @@ def __get_previous_month_dates(current_date: date) -> Tuple[date, date]:
     year = last_day_of_previous_month.year
     month = last_day_of_previous_month.month
     return date(year, month, 1), date(year, month, calendar.monthrange(year, month)[1])
+
+
+DEFAULT_DATE_RANGE_FUNCTIONS = {
+    "YESTERDAY": __get_yesterday_date,
+    "LAST_7_DAYS": __get_last_7d_dates,
+    "PREVIOUS_WEEK": __get_previous_week_dates,
+    "PREVIOUS_MONTH": __get_previous_month_dates,
+    "LAST_90_DAYS": __get_last_90d_dates,
+}
+
+
+def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date, date]:
+    current_date = date.today()
+    return DEFAULT_DATE_RANGE_FUNCTIONS[date_range](current_date)

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -38,5 +38,14 @@ DEFAULT_DATE_RANGE_FUNCTIONS = {
 
 
 def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date, date]:
+    """Returns date start and date stop based on the date range provided
+    and the current date.
+
+    Args:
+        date_range (str): One of the default date ranges that exist
+
+    Returns:
+        Tuple[date, date]: date start and date stop that match the date range
+    """
     current_date = date.today()
     return DEFAULT_DATE_RANGE_FUNCTIONS[date_range](current_date)

--- a/tests/readers/test_adobe_reader_2_0.py
+++ b/tests/readers/test_adobe_reader_2_0.py
@@ -36,6 +36,7 @@ class AdobeReaderTest_2_0(TestCase):
         "metric": [],
         "start_date": datetime.date(2020, 1, 1),
         "end_date": datetime.date(2020, 1, 2),
+        "date_range": None,
     }
 
     @mock.patch("nck.clients.adobe_client.AdobeClient.__init__", return_value=None)
@@ -78,9 +79,7 @@ class AdobeReaderTest_2_0(TestCase):
         metrics = ["visits", "bounces"]
         breakdown_item_ids = ["000000000", "111111111"]
 
-        output = AdobeReader_2_0(**temp_kwargs).build_report_description(
-            metrics, breakdown_item_ids
-        )
+        output = AdobeReader_2_0(**temp_kwargs).build_report_description(metrics, breakdown_item_ids)
         expected = {
             "rsid": "XXXXXXXXX",
             "globalFilters": [
@@ -163,9 +162,7 @@ class AdobeReaderTest_2_0(TestCase):
         )
         metrics = ["visits", "bounces"]
 
-        output = AdobeReader_2_0(**temp_kwargs).get_parsed_report(
-            {"dimension": "variables/daterangeday"}, metrics
-        )
+        output = AdobeReader_2_0(**temp_kwargs).get_parsed_report({"dimension": "variables/daterangeday"}, metrics)
         expected = [
             {"daterangeday": "2020-01-01", "visits": 11, "bounces": 21},
             {"daterangeday": "2020-01-02", "visits": 12, "bounces": 22},
@@ -192,9 +189,7 @@ class AdobeReaderTest_2_0(TestCase):
         node = "daterangeday_1200201"
         path_to_node = ["daterangeday_1200201"]
 
-        output = AdobeReader_2_0(**self.kwargs).add_child_nodes_to_graph(
-            graph, node, path_to_node
-        )
+        output = AdobeReader_2_0(**self.kwargs).add_child_nodes_to_graph(graph, node, path_to_node)
         expected = {
             "root": ["daterangeday_1200201", "daterangeday_1200202"],
             "daterangeday_1200201": ["lasttouchchannel_1", "lasttouchchannel_2"],
@@ -212,13 +207,9 @@ class AdobeReaderTest_2_0(TestCase):
             {"daterangeday": "2020-01-02", "visits": 12, "bounces": 22},
         ],
     )
-    def test_read_one_dimension_reports(
-        self, mock_adobe_client, mock_get_parsed_report
-    ):
+    def test_read_one_dimension_reports(self, mock_adobe_client, mock_get_parsed_report):
         temp_kwargs = self.kwargs.copy()
-        temp_kwargs.update(
-            {"dimension": ["daterangeday"], "metric": ["visits", "bounces"]}
-        )
+        temp_kwargs.update({"dimension": ["daterangeday"], "metric": ["visits", "bounces"]})
 
         output = next(AdobeReader_2_0(**temp_kwargs).read())
         expected = [
@@ -289,9 +280,7 @@ class AdobeReaderTest_2_0(TestCase):
             ],
         ],
     )
-    def test_read_multiple_dimension_reports(
-        self, mock_adobe_client, mock_add_child_nodes_to_graph, mock_get_parsed_report
-    ):
+    def test_read_multiple_dimension_reports(self, mock_adobe_client, mock_add_child_nodes_to_graph, mock_get_parsed_report):
         temp_kwargs = self.kwargs.copy()
         temp_kwargs.update(
             {

--- a/tests/utils/test_date_handler.py
+++ b/tests/utils/test_date_handler.py
@@ -1,60 +1,49 @@
-from datetime import date
 import unittest
-from unittest.mock import patch
+from datetime import date
 
+from freezegun import freeze_time
+from nck.utils.date_handler import get_date_start_and_date_stop_from_date_range
 from parameterized import parameterized
-
-from nck.utils.date_handler import get_date_start_and_date_stop_from_range
 
 
 class TestDateHandler(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("YESTERDAY", (date(2021, 1, 12), date(2021, 1, 12))),
+            ("LAST_7_DAYS", (date(2021, 1, 5), date(2021, 1, 12))),
+            ("LAST_90_DAYS", (date(2020, 10, 14), date(2021, 1, 12))),
+        ]
+    )
+    @freeze_time("2021-01-13")
+    def test_get_date_start_and_date_stop_from_date_range(self, date_range, expected):
+        self.assertTupleEqual(get_date_start_and_date_stop_from_date_range(date_range), expected)
 
-    @parameterized.expand([
-        (
-            date(2020, 2, 1),
-            (date(2020, 1, 1), date(2020, 1, 31))
-        ),
-        (
-            date(2020, 1, 1),
-            (date(2019, 12, 1), date(2019, 12, 31))
-        ),
-        (
-            date(2020, 2, 15),
-            (date(2020, 1, 1), date(2020, 1, 31))
-        ),
-        (
-            date(2019, 12, 1),
-            (date(2019, 11, 1), date(2019, 11, 30))
+    @freeze_time("2021-01-11")
+    def test_get_previous_week_dates_if_monday(self):
+        self.assertTupleEqual(
+            get_date_start_and_date_stop_from_date_range("PREVIOUS_WEEK"), (date(2021, 1, 4), date(2021, 1, 10))
         )
-    ])
-    def test_get_date_start_and_date_stop_with_previous_month(self, date_of_day, expected):
-        input_range = "PREVIOUS_MONTH"
-        with patch("nck.utils.date_handler.date") as mock_date:
-            mock_date.today.return_value = date_of_day
-            mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
-            self.assertTupleEqual(
-                expected,
-                get_date_start_and_date_stop_from_range(input_range),
-                f"Bad return when freezed date is {date_of_day}"
-            )
 
-    @parameterized.expand([
-        (
-            date(2020, 1, 6),
-            (date(2019, 12, 29), date(2020, 1, 4))
-        ),
-        (
-            date(2020, 1, 13),
-            (date(2020, 1, 5), date(2020, 1, 11))
+    @freeze_time("2021-01-13")
+    def test_get_previous_week_dates_if_midweek(self):
+        self.assertTupleEqual(
+            get_date_start_and_date_stop_from_date_range("PREVIOUS_WEEK"), (date(2021, 1, 4), date(2021, 1, 10))
         )
-    ])
-    def test_get_date_start_and_date_stop_with_previous_week(self, date_of_day, expected):
-        input_range = "PREVIOUS_WEEK"
-        with patch("nck.utils.date_handler.date") as mock_date:
-            mock_date.today.return_value = date_of_day
-            mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
-            self.assertTupleEqual(
-                expected,
-                get_date_start_and_date_stop_from_range(input_range),
-                f"Bad return when freezed date is {date_of_day}"
-            )
+
+    @freeze_time("2021-01-17")
+    def test_get_previous_week_dates_if_sunday(self):
+        self.assertTupleEqual(
+            get_date_start_and_date_stop_from_date_range("PREVIOUS_WEEK"), (date(2021, 1, 4), date(2021, 1, 10))
+        )
+
+    @freeze_time("2021-01-11")
+    def test_get_previous_month_dates_if_first_month_of_the_year(self):
+        self.assertTupleEqual(
+            get_date_start_and_date_stop_from_date_range("PREVIOUS_MONTH"), (date(2020, 12, 1), date(2020, 12, 31))
+        )
+
+    @freeze_time("2021-02-11")
+    def test_get_previous_month_dates_if_random_month_of_the_year(self):
+        self.assertTupleEqual(
+            get_date_start_and_date_stop_from_date_range("PREVIOUS_MONTH"), (date(2021, 1, 1), date(2021, 1, 31))
+        )


### PR DESCRIPTION
### Issue

My PR addresses the Issue #82 

### Description

This PR brings the skeleton for default date ranges. This PR only implements the feature in one reader: adobe v2 but it will be very easy to add this feature to other readers and I can take care of that.

So, now you can use the `--adobe-2-0-date-range YESTERDAY` option for example to test the feature.

### Tests

My PR adds test for the logic of date start and date stop generation.

### Documentation

- [x] add documentation for adobe reader and a docstring for the function that is exposed for date start and date stop generation