### PR TITLE
fix: raise csv field limit value to 1 000 000

### DIFF
--- a/nck/utils/file_reader.py
+++ b/nck/utils/file_reader.py
@@ -22,6 +22,8 @@ import gzip
 import zipfile
 import json
 
+csv.field_size_limit(1000000)
+
 
 def unzip(input_file, output_path):
     with zipfile.ZipFile(input_file, 'r') as zip_ref:


### PR DESCRIPTION
### Issue

- [x] Fix needed: the default .csv field_size_limit is exceeded while making requests with the DV360 reader #81 

### Description

- [x] Since the csv field limit was the issue here I raised the limit from the default (131K) to 1 000 000 limit.

### Tests

- [ ] It works locally but now we need to check if the perf are similar or if there is a significant decrease.

### Commits

- [x] I have set the csv field limit value to 1 000 000 in nck/utils/file_reader.py
