### PR TITLE
feat/add customer id granularity for mcc use

### DIFF
--- a/nck/utils/exceptions.py
+++ b/nck/utils/exceptions.py
@@ -27,3 +27,8 @@ class SdfOperationError(Exception):
     """Raised when a sdf operation has failed."""
 
     pass
+
+
+class NoValidCustomerIdProvidedInMCC(Exception):
+    """Raised when customer ids are not under the provided mcc id"""
+    pass

--- a/nck/utils/list_comparator.py
+++ b/nck/utils/list_comparator.py
@@ -1,0 +1,10 @@
+from typing import List
+
+
+def get_intersection_two_lists(list_a: List[str], list_b: List[str]) -> List[str]:
+    return list(set(list_a) & set(list_b))
+
+
+def get_difference_two_list_order(list_a: List[str], list_b: List[str]) -> List[str]:
+    """This function will return a list of elements from list a which are not in list b."""
+    return list(set(list_a).difference(list_b))

--- a/tests/utils/test_list_comparator.py
+++ b/tests/utils/test_list_comparator.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+from parameterized import parameterized
+from nck.utils.list_comparator import (
+    get_difference_two_list_order,
+    get_intersection_two_lists
+)
+
+
+class TestIntersectionTwoLists(TestCase):
+    @parameterized.expand(
+        [
+            ([], [], []),
+            ([], ["1"], []),
+            (["1", "2", "3"], ["4", "5", "6"], []),
+            (["1", "2", "3"], ["4", "2", "6"], ["2"]),
+            (["1", "2", "3"], ["2", "5", "1"], ["1", "2"]),
+            (["1", "2", "3"], ["2", "2", "1"], ["1", "2"]),
+            (["1", "2", "1"], ["2", "2", "1"], ["1", "2"]),
+            (["1", "2", "3"], ["3", "2", "1"], ["1", "2", "3"]),
+            (["1", "2", "3"], ["3", "2", "1", "4"], ["1", "2", "3"])
+        ]
+    )
+    def test_get_intersection_two_lists(self, input_list_a, input_list_b, expected):
+        self.assertEqual(sorted(get_intersection_two_lists(input_list_a, input_list_b)), expected)
+
+
+class TestDifferenceTwoListOrder(TestCase):
+    @parameterized.expand(
+        [
+            ([], [], []),
+            ([], ["1"], []),
+            (["1", "2", "1"], ["2", "2", "1"], []),
+            (["1", "2", "3"], ["3", "2", "1"], []),
+            (["1", "2", "3"], ["4", "3", "2", "1"], []),
+            (["1", "2", "3"], ["2", "5", "1"], ["3"]),
+            (["1", "2", "3"], ["2", "2", "1"], ["3"]),
+            (["1", "1", "1"], ["3", "2", "2"], ["1"]),
+            (["1", "2", "3", "4"], ["3", "2", "1"], ["4"]),
+            (["1", "2", "3"], ["4", "2", "6"], ["1", "3"]),
+            (["1", "2", "3"], ["4", "5", "6"], ["1", "2", "3"]),
+            (["1", "2", "3"], ["4", "5", "6", "7"], ["1", "2", "3"]),
+        ]
+    )
+    def test_get_difference_two_list_order(self, input_list_a, input_list_b, expected):
+        self.assertEqual(sorted(get_difference_two_list_order(input_list_a, input_list_b)), expected)


### PR DESCRIPTION
### Description

- [x] The number of advertiser (customer) ids which can be linked to an account is limited to 20. To bypass this limitation is it advised to use an MCC id which is call manager id here. From this MCC you can access all the data for the customer ids which are "bellow" this MCC. For example if ids "1" and "2" are linked to the MCC you can use the MCC creds to access both of these ids. For now we can do so by specifying a manager id and we get all the ids linked to the MCC. Nevertheless we encountered a limitation in one of our use cases for our client: what if we only want to retrieve a specific subset of ids under the mcc ?

To solve this issue, I created a method to update the customer ids which will be used to query the API. This update will compare the customer ids valid for the MCC to the ones we provided.

Cases covered:
1) (New case) Manager id and customer ids provided: 
  - A warning will appear in the case where some ids provided are not linked to the mcc.
  - If none of the ids provided are linked to the mcc we raise a dedicated exception.
  - If one or more ids provided are linked to the mcc we set them as the customer ids used for the query.
2) (Already existing) Manager id provided but no customer id:
  - If no customer id is given as an input we get all the linked ids as before and use them for the query.
3) (Already existing) No manager id provided but customer ids:
  - We don't update customer ids.

IMPORTANT: @gabrielleberanger do you think this interferes with your current use of the googleads connector for the projects with your client ?

### Tests

- [x] My PR adds the following unit tests : tests for the functions used to get the invalid ids but also the common ids between ids linked to mcc and customer ids provided. => tests/utils/test_list_comparator
- [ ] NOT DONE YET: test the update function ?

### Commits

- [x] Add tests to cover the function
- [x] Add a custom exception
- [x] Create list comparator to get correct ids and warn if some ids are not linked to the mcc
- [x] Create a function to update the customer ids given to the query

### Documentation

- [x] -> See docstrings and tests.
- [x] -> See example below of a case where only one id is linked to the mcc but the other are not. 
<img width="1071" alt="Capture d’écran 2021-02-11 à 17 04 36" src="https://user-images.githubusercontent.com/71007966/107679426-d8077f00-6c9c-11eb-81a9-18e222384b4a.png">
