### PR TITLE
add normalize-keys at entrypoint

### DIFF
--- a/nck/readers/reader.py
+++ b/nck/readers/reader.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
 class Reader:
     def read(self):
         """


### PR DESCRIPTION
### Issue

- [x] My PR introduces the issue #103.
In fact, some readers return normalized streams. They should return non-normalized streams.

### Description

Retrieve --normalize-keys at entrypoint in order to normalize the output JSONstreams if needed.

**Example:**
```
python nck/entrypoint/py --normalize-keys true <reader> [...] <writer>
```
=> if `<reader>` initially returns a JSONStream, the stream will be changed in a NormalizedJSONStream