### PR TITLE
fix: edit reader/writer instanciation

### DIFF
--- a/nck/entrypoint.py
+++ b/nck/entrypoint.py
@@ -41,17 +41,17 @@ def build_commands(cli, available_commands):
 
 @cli.resultcallback()
 def process_command_pipeline(provided_commands, normalize_keys):
-    provided_readers = [cmd() for cmd in provided_commands if isinstance(cmd(), Reader)]
-    provided_writers = [cmd() for cmd in provided_commands if isinstance(cmd(), Writer)]
+    provided_readers = [cmd for cmd in provided_commands if isinstance(cmd(), Reader)]
+    provided_writers = [cmd for cmd in provided_commands if isinstance(cmd(), Writer)]
     _validate_provided_commands(provided_readers, provided_writers)
 
     reader = provided_readers[0]
-    for stream in reader.read():
+    for stream in reader().read():
         for writer in provided_writers:
             if normalize_keys and issubclass(stream.__class__, JSONStream):
-                writer.write(NormalizedJSONStream.create_from_stream(stream))
+                writer().write(NormalizedJSONStream.create_from_stream(stream))
             else:
-                writer.write(stream)
+                writer().write(stream)
 
 
 def _validate_provided_commands(provided_readers, provided_writers):

--- a/nck/entrypoint.py
+++ b/nck/entrypoint.py
@@ -41,17 +41,17 @@ def build_commands(cli, available_commands):
 
 @cli.resultcallback()
 def process_command_pipeline(provided_commands, normalize_keys):
-    provided_readers = [cmd for cmd in provided_commands if isinstance(cmd(), Reader)]
-    provided_writers = [cmd for cmd in provided_commands if isinstance(cmd(), Writer)]
-    _validate_provided_commands(provided_readers, provided_writers)
+    cmd_instances = [cmd() for cmd in provided_commands]
+    provided_readers = list(filter(lambda o: isinstance(o, Reader), cmd_instances))
+    provided_writers = list(filter(lambda o: isinstance(o, Writer), cmd_instances))
 
     reader = provided_readers[0]
-    for stream in reader().read():
+    for stream in reader.read():
         for writer in provided_writers:
             if normalize_keys and issubclass(stream.__class__, JSONStream):
-                writer().write(NormalizedJSONStream.create_from_stream(stream))
+                writer.write(NormalizedJSONStream.create_from_stream(stream))
             else:
-                writer().write(stream)
+                writer.write(stream)
 
 
 def _validate_provided_commands(provided_readers, provided_writers):


### PR DESCRIPTION
### Description

- [x] Encountered an issue for mytarget tokens generation an usage due to the fact that there

### Commits

- [x] Just edit the moment when the instance is created.

IMPORTANT NOTE: There is an issue with the entrypoint which is more general and who might need a small fix. When generating the list of provided readers and writers in the entrypoint.py file instances are created in the isinstance(cmd(), Reader/Writer). This causes 3 initiations of our classes instead of one which can lead to issues or useless logs. Maybe using class variables instead of Reader/Writer objects would be better to retrieve the correct cmds. Is there a specific reason why it is how it is today or can we fix this later ? @bibimorlet @gabrielleberanger @benoitgoujon 