### PR TITLE
Predefined date range option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.10b0
     hooks:
       - id: black
         entry: black

--- a/nck/readers/mytarget_reader.py
+++ b/nck/readers/mytarget_reader.py
@@ -27,11 +27,7 @@ from nck.readers.reader import Reader
 from nck.streams.json_stream import JSONStream
 from nck.utils.exceptions import MissingItemsInResponse
 from nck.utils.args import extract_args
-from nck.utils.date_handler import (
-    DEFAULT_DATE_RANGE_FUNCTIONS,
-    check_date_range_definition_conformity,
-    get_date_start_and_date_stop_from_date_range,
-)
+from nck.utils.date_handler import DEFAULT_DATE_RANGE_FUNCTIONS, build_date_range
 
 
 @click.command(name="read_mytarget")
@@ -56,16 +52,11 @@ LIMIT_REQUEST_MYTARGET = 20
 
 class MyTargetReader(Reader):
     def __init__(self, client_id, client_secret, refresh_token, request_type, date_range, start_date, end_date, **kwargs):
-        check_date_range_definition_conformity(start_date, end_date, date_range)
-        if date_range is not None:
-            start_date, end_date = get_date_start_and_date_stop_from_date_range(date_range)
         self.client_id = client_id
         self.client_secret = client_secret
         self.agency_client_token = {"refresh_token": refresh_token}
         self.request_type = request_type
-        self.date_range = date_range
-        self.start_date = start_date
-        self.end_date = end_date
+        self.start_date, self.end_date = build_date_range(start_date, end_date, date_range)
         self.date_format = kwargs.get("date_format")
         self.date_are_valid = self.__check_date_input_validity()
         self.__retrieve_and_set_token()

--- a/nck/readers/mytarget_reader.py
+++ b/nck/readers/mytarget_reader.py
@@ -93,12 +93,6 @@ class MyTargetReader(Reader):
         else:
             return True
 
-    def __get_valid_start_date_end_date(self, date_range: str, start_date: datetime, end_date: datetime):
-        if date_range is not None:
-            return get_date_start_and_date_stop_from_date_range(date_range)
-        else:
-            return (start_date.date(), end_date.date())
-
     def __retrieve_and_set_token(self):
         """In order to request the api, we need an active token. To do so we use the token which
         was provided to get a new one which is going to be active for a day. Once done we set it
@@ -158,9 +152,7 @@ class MyTargetReader(Reader):
             dict_banner.pop(unused_ban_id)
         return dict_banner
 
-    def map_budget_to_date_range(
-        self, dates: Dict[str, str], budgets: List[Dict[str, str]]
-    ) -> List[Dict[str, str]]:
+    def map_budget_to_date_range(self, dates: Dict[str, str], budgets: List[Dict[str, str]]) -> List[Dict[str, str]]:
         result = []
         dates_dict = self.__transform_list_dict_to_dict(dates)
         for budget in budgets:

--- a/nck/readers/search_console_reader.py
+++ b/nck/readers/search_console_reader.py
@@ -80,8 +80,6 @@ class SearchConsoleReader(Reader):
         self.dimensions = list(dimensions)
         self.site_url = site_url
         self.start_date, self.end_date = build_date_range(start_date, end_date, date_range)
-        self.start_date = datetime.strftime(self.start_date, DATEFORMAT)
-        self.end_date = datetime.strftime(self.check_end_date(self.end_date), DATEFORMAT)
         self.with_date_column = date_column
         self.row_limit = row_limit
 
@@ -109,21 +107,15 @@ class SearchConsoleReader(Reader):
 
     @staticmethod
     def check_end_date(end_date):
-        # adapt the class to be able to compare end_date with MAX_END_DATE (datetime)
-        if isinstance(end_date, datetime):
-            max_end_date = MAX_END_DATE
-        else:
-            max_end_date = MAX_END_DATE.date()
-
-        if end_date > max_end_date:
+        if end_date > MAX_END_DATE:
             logger.warning(f"The most recent date you can request is {datetime.strftime(MAX_END_DATE, DATEFORMAT)}")
         return end_date
 
     def build_query(self):
 
         query = {
-            "startDate": self.start_date,
-            "endDate": self.end_date,
+            "startDate": datetime.strftime(self.start_date, DATEFORMAT),
+            "endDate": datetime.strftime(self.check_end_date(self.end_date), DATEFORMAT),
             "dimensions": self.dimensions,
             "startRow": self.start_row,
             "rowLimit": self.row_limit,
@@ -156,7 +148,7 @@ class SearchConsoleReader(Reader):
 
             for dimension, key in zip(self.dimensions, keys):
                 if self.with_date_column:
-                    record["date"] = self.start_date
+                    record["date"] = datetime.strftime(self.start_date, DATEFORMAT)
                 record[dimension] = key
 
             for metric in metric_names:

--- a/nck/readers/ttd_reader.py
+++ b/nck/readers/ttd_reader.py
@@ -12,7 +12,6 @@
 
 from nck.config import logger
 import click
-from click import ClickException
 import requests
 from datetime import timedelta
 from tenacity import retry, wait_exponential, stop_after_delay
@@ -78,12 +77,6 @@ class TheTradeDeskReader(Reader):
         self.start_date, self.end_date = build_date_range(start_date, end_date, date_range)
         # Report end date is exclusive: to become inclusive, it should be incremented by 1 day
         self.end_date = self.end_date + timedelta(days=1)
-
-        self._validate_dates()
-
-    def _validate_dates(self):
-        if self.end_date - timedelta(days=1) < self.start_date:
-            raise ClickException("Report end date should be equal or ulterior to report start date.")
 
     def _get_access_token(self):
         url = f"{API_HOST}/authentication"

--- a/nck/readers/ttd_reader.py
+++ b/nck/readers/ttd_reader.py
@@ -38,10 +38,7 @@ from nck.utils.text import get_report_generator_from_flat_file
 @click.option("--ttd-login", required=True, help="Login of your API account")
 @click.option("--ttd-password", required=True, help="Password of your API account")
 @click.option(
-    "--ttd-advertiser-id",
-    required=True,
-    multiple=True,
-    help="Advertiser Ids for which report data should be fetched",
+    "--ttd-advertiser-id", required=True, multiple=True, help="Advertiser Ids for which report data should be fetched",
 )
 @click.option(
     "--ttd-report-template-name",
@@ -59,12 +56,6 @@ from nck.utils.text import get_report_generator_from_flat_file
     "--ttd-end-date", type=click.DateTime(), help="End date of the period to request (format: YYYY-MM-DD)",
 )
 @click.option(
-    "--ttd-end-date",
-    required=True,
-    type=click.DateTime(),
-    help="End date of the period to request (format: YYYY-MM-DD)",
-)
-@click.option(
     "--ttd-date-range",
     type=click.Choice(DEFAULT_DATE_RANGE_FUNCTIONS.keys()),
     help=f"One of the available NCK default date ranges: {DEFAULT_DATE_RANGE_FUNCTIONS.keys()}",
@@ -76,16 +67,7 @@ def the_trade_desk(**kwargs):
 
 class TheTradeDeskReader(Reader):
     def __init__(
-        self,
-        login,
-        password,
-        advertiser_id,
-        report_template_name,
-        report_schedule_name,
-        start_date,
-        end_date,
-        normalize_stream,
-        date_range,
+        self, login, password, advertiser_id, report_template_name, report_schedule_name, start_date, end_date, date_range,
     ):
         self.login = login
         self.password = password
@@ -96,7 +78,6 @@ class TheTradeDeskReader(Reader):
         self.start_date, self.end_date = build_date_range(start_date, end_date, date_range)
         # Report end date is exclusive: to become inclusive, it should be incremented by 1 day
         self.end_date = self.end_date + timedelta(days=1)
-        self.normalize_stream = normalize_stream
 
         self._validate_dates()
 
@@ -161,8 +142,7 @@ class TheTradeDeskReader(Reader):
         self.report_schedule_id = json_response["ReportScheduleId"]
 
     @retry(
-        wait=wait_exponential(multiplier=1, min=60, max=3600),
-        stop=stop_after_delay(36000),
+        wait=wait_exponential(multiplier=1, min=60, max=3600), stop=stop_after_delay(36000),
     )
     def _wait_for_download_url(self):
         report_execution_details = self._get_report_execution_details()

--- a/nck/readers/twitter_reader.py
+++ b/nck/readers/twitter_reader.py
@@ -40,6 +40,8 @@ from twitter_ads.cursor import Cursor
 # from twitter_ads.creative import TweetPreview
 from twitter_ads.creative import CardsFetch
 
+from nck.utils.date_handler import DEFAULT_DATE_RANGE_FUNCTIONS, build_date_range
+
 API_DATEFORMAT = "%Y-%m-%dT%H:%M:%SZ"
 REP_DATEFORMAT = "%Y-%m-%d"
 MAX_WAITING_SEC = 3600
@@ -136,6 +138,11 @@ MAX_CONCURRENT_JOBS = 100
     default=False,
     help="If set to 'True', the date on which the request is made will appear on each report record.",
 )
+@click.option(
+    "--twitter-date-range",
+    type=click.Choice(DEFAULT_DATE_RANGE_FUNCTIONS.keys()),
+    help=f"One of the available NCK default date ranges: {DEFAULT_DATE_RANGE_FUNCTIONS.keys()}",
+)
 @processor(
     "twitter_consumer_key", "twitter_consumer_secret", "twitter_access_token", "twitter_access_token_secret",
 )
@@ -163,6 +170,7 @@ class TwitterReader(Reader):
         start_date,
         end_date,
         add_request_date_to_report,
+        date_range,
     ):
         # Authentication inputs
         self.client = Client(consumer_key, consumer_secret, access_token, access_token_secret)
@@ -171,8 +179,8 @@ class TwitterReader(Reader):
         # General inputs
         self.report_type = report_type
         self.entity = entity
-        self.start_date = start_date
-        self.end_date = end_date + timedelta(days=1)
+        self.start_date, self.end_date = build_date_range(start_date, end_date, date_range)
+        self.end_date = self.end_date + timedelta(days=1)
         self.add_request_date_to_report = add_request_date_to_report
 
         # Report inputs: ENTITY

--- a/nck/readers/twitter_reader.py
+++ b/nck/readers/twitter_reader.py
@@ -202,17 +202,11 @@ class TwitterReader(Reader):
         Validate combination of input parameters (triggered in TwitterReader constructor).
         """
 
-        self.validate_dates()
         self.validate_analytics_segmentation()
         self.validate_analytics_metric_groups()
         self.validate_analytics_entity()
         self.validate_reach_entity()
         self.validate_entity_attributes()
-
-    def validate_dates(self):
-
-        if self.end_date - timedelta(days=1) < self.start_date:
-            raise ClickException("Report end date should be equal or ulterior to report start date.")
 
     def validate_analytics_segmentation(self):
 

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -65,22 +65,12 @@ def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date,
     return DEFAULT_DATE_RANGE_FUNCTIONS[date_range](current_date)
 
 
-def build_date_range(start_date, end_date, date_range):
-    """Returns date start and date end adapted if there is a date range.
-
-    Args:
-        start_date (date): start date
-        end_date (date): end date
-        date_range (str): One of the default date ranges that exist
-
-    Returns:
-        Tuple[datetime, datetime]: date start and date stop that match the date range
-    """
+def build_date_range(start_date: date, end_date: date, date_range: str) -> Tuple[datetime, datetime]:
     check_date_range_definition_conformity(start_date, end_date, date_range)
 
     if date_range is not None:
         start_date, end_date = get_date_start_and_date_stop_from_date_range(date_range)
-        start_date = datetime.combine(start_date, datetime.min.time())
-        end_date = datetime.combine(end_date, datetime.min.time())
+        start_date = datetime(start_date.year, start_date.month, start_date.day)
+        end_date = datetime(end_date.year, end_date.month, end_date.day)
 
     return start_date, end_date

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -66,3 +66,22 @@ def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date,
     """
     current_date = date.today()
     return DEFAULT_DATE_RANGE_FUNCTIONS[date_range](current_date)
+
+
+def build_date_range(start_date, end_date, date_range):
+    """Returns date start and date end adapted if there is a date range.
+
+    Args:
+        start_date (date): start date
+        end_date (date): end date
+        date_range (str): One of the default date ranges that exist
+
+    Returns:
+        Tuple[date, date]: date start and date stop that match the date range
+    """
+    check_date_range_definition_conformity(start_date, end_date, date_range)
+
+    if date_range is not None:
+        start_date, end_date = get_date_start_and_date_stop_from_date_range(date_range)
+
+    return start_date, end_date

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -1,5 +1,5 @@
 import calendar
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 from typing import Tuple
 
 from nck.utils.exceptions import DateDefinitionException
@@ -74,11 +74,13 @@ def build_date_range(start_date, end_date, date_range):
         date_range (str): One of the default date ranges that exist
 
     Returns:
-        Tuple[date, date]: date start and date stop that match the date range
+        Tuple[datetime, datetime]: date start and date stop that match the date range
     """
     check_date_range_definition_conformity(start_date, end_date, date_range)
 
     if date_range is not None:
         start_date, end_date = get_date_start_and_date_stop_from_date_range(date_range)
+        start_date = datetime.combine(start_date, datetime.min.time())
+        end_date = datetime.combine(end_date, datetime.min.time())
 
     return start_date, end_date

--- a/tests/readers/test_adobe_reader_2_0.py
+++ b/tests/readers/test_adobe_reader_2_0.py
@@ -40,8 +40,8 @@ class AdobeReaderTest_2_0(TestCase):
     }
 
     @mock.patch("nck.clients.adobe_client.AdobeClient.__init__", return_value=None)
-    def test_build_date_range(self, mock_adobe_client):
-        output = AdobeReader_2_0(**self.kwargs).build_date_range()
+    def test_format_date_range(self, mock_adobe_client):
+        output = AdobeReader_2_0(**self.kwargs).format_date_range()
         expected = "2020-01-01T00:00:00/2020-01-03T00:00:00"
         self.assertEqual(output, expected)
 

--- a/tests/readers/test_search_console_reader.py
+++ b/tests/readers/test_search_console_reader.py
@@ -36,6 +36,7 @@ class SearchConsoleReaderTest(TestCase):
             "end_date": datetime(2019, 1, 1),
             "date_column": False,
             "row_limit": "",
+            "date_range": None,
         }
         reader = SearchConsoleReader(**kwargs)
 

--- a/tests/readers/test_ttd.py
+++ b/tests/readers/test_ttd.py
@@ -34,7 +34,6 @@ class TheTradeDeskReaderTest(TestCase):
         "report_schedule_name": "adgroup_performance_schedule",
         "start_date": datetime(2020, 1, 1),
         "end_date": datetime(2020, 3, 1),
-        "normalize_stream": False,
         "date_range": None,
     }
 

--- a/tests/readers/test_ttd.py
+++ b/tests/readers/test_ttd.py
@@ -33,7 +33,8 @@ class TheTradeDeskReaderTest(TestCase):
         "report_schedule_name": "adgroup_performance_schedule",
         "start_date": datetime(2020, 1, 1),
         "end_date": datetime(2020, 3, 1),
-        "normalize_stream": False
+        "normalize_stream": False,
+        "date_range": None,
     }
 
     @mock.patch("nck.readers.ttd_reader.TheTradeDeskReader._build_headers", return_value={})
@@ -60,9 +61,7 @@ class TheTradeDeskReaderTest(TestCase):
             "ResultCount": 1,
         },
     )
-    def test_get_report_template_id_if_exactly_1_match(
-        self, mock_build_headers, mock_api_call
-    ):
+    def test_get_report_template_id_if_exactly_1_match(self, mock_build_headers, mock_api_call):
         reader = TheTradeDeskReader(**self.kwargs)
         reader._get_report_template_id()
         self.assertEqual(reader.report_template_id, 1234)
@@ -90,30 +89,22 @@ class TheTradeDeskReaderTest(TestCase):
             "ResultCount": 2,
         },
     )
-    def test_get_report_template_id_if_more_than_1_match(
-        self, mock_build_headers, mock_api_call
-    ):
+    def test_get_report_template_id_if_more_than_1_match(self, mock_build_headers, mock_api_call):
         with self.assertRaises(Exception):
             TheTradeDeskReader(**self.kwargs)._get_report_template_id()
 
     @mock.patch("nck.readers.ttd_reader.TheTradeDeskReader._build_headers", return_value={})
     @mock.patch(
-        "nck.readers.ttd_reader.TheTradeDeskReader._make_api_call",
-        return_value={"Result": [], "ResultCount": 0},
+        "nck.readers.ttd_reader.TheTradeDeskReader._make_api_call", return_value={"Result": [], "ResultCount": 0},
     )
-    def test_get_report_template_id_if_no_match(
-        self, mock_build_headers, mock_api_call
-    ):
+    def test_get_report_template_id_if_no_match(self, mock_build_headers, mock_api_call):
         with self.assertRaises(Exception):
             TheTradeDeskReader(**self.kwargs)._get_report_template_id()
 
     @mock.patch("nck.readers.ttd_reader.TheTradeDeskReader._build_headers", return_value={})
     @mock.patch(
         "nck.readers.ttd_reader.TheTradeDeskReader._make_api_call",
-        return_value={
-            "ReportScheduleId": 5678,
-            "ReportScheduleName": "adgroup_performance_schedule",
-        },
+        return_value={"ReportScheduleId": 5678, "ReportScheduleName": "adgroup_performance_schedule"},
     )
     def test_create_report_schedule(self, mock_build_headers, mock_api_call):
         reader = TheTradeDeskReader(**self.kwargs)
@@ -167,21 +158,9 @@ class TheTradeDeskReaderTest(TestCase):
         "nck.readers.ttd_reader.TheTradeDeskReader._download_report",
         return_value=iter(
             [
-                {
-                    "Date": "2020-01-01T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 10
-                },
-                {
-                    "Date": "2020-02-01T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 11
-                },
-                {
-                    "Date": "2020-02-03T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 12
-                },
+                {"Date": "2020-01-01T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 10},
+                {"Date": "2020-02-01T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 11},
+                {"Date": "2020-02-03T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 12},
             ]
         ),
     )
@@ -208,21 +187,9 @@ class TheTradeDeskReaderTest(TestCase):
         "nck.readers.ttd_reader.TheTradeDeskReader._download_report",
         return_value=iter(
             [
-                {
-                    "Date": "2020-01-01T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 10,
-                },
-                {
-                    "Date": "2020-02-01T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 11,
-                },
-                {
-                    "Date": "2020-02-03T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 12,
-                },
+                {"Date": "2020-01-01T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 10},
+                {"Date": "2020-02-01T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 11},
+                {"Date": "2020-02-03T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 12},
             ]
         ),
     )

--- a/tests/readers/test_ttd.py
+++ b/tests/readers/test_ttd.py
@@ -20,7 +20,8 @@ from unittest import TestCase, mock
 from nck.readers.ttd_reader import TheTradeDeskReader
 
 from datetime import datetime
-from click import ClickException
+
+from nck.utils.exceptions import DateDefinitionException
 
 
 class TheTradeDeskReaderTest(TestCase):
@@ -42,7 +43,7 @@ class TheTradeDeskReaderTest(TestCase):
         temp_kwargs = self.kwargs.copy()
         params = {"start_date": datetime(2020, 1, 3), "end_date": datetime(2020, 1, 1)}
         temp_kwargs.update(params)
-        with self.assertRaises(ClickException):
+        with self.assertRaises(DateDefinitionException):
             TheTradeDeskReader(**temp_kwargs)
 
     @mock.patch("nck.readers.ttd_reader.TheTradeDeskReader._build_headers", return_value={})
@@ -177,5 +178,3 @@ class TheTradeDeskReaderTest(TestCase):
         ]
         for output_record, expected_record in zip(output.readlines(), iter(expected)):
             self.assertEqual(output_record, expected_record)
-
-            

--- a/tests/readers/test_twitter_reader.py
+++ b/tests/readers/test_twitter_reader.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from twitter_ads.client import Client
 
 from nck.readers.twitter_reader import TwitterReader
+from nck.utils.exceptions import DateDefinitionException
 
 
 class TwitterReaderTest(TestCase):
@@ -55,7 +56,7 @@ class TwitterReaderTest(TestCase):
         temp_kwargs = self.kwargs.copy()
         params = {"start_date": datetime(2020, 1, 3), "end_date": datetime(2020, 1, 1)}
         temp_kwargs.update(params)
-        with self.assertRaises(ClickException):
+        with self.assertRaises(DateDefinitionException):
             TwitterReader(**temp_kwargs)
 
     @mock.patch.object(Client, "__init__", lambda *args: None)

--- a/tests/readers/test_twitter_reader.py
+++ b/tests/readers/test_twitter_reader.py
@@ -46,6 +46,7 @@ class TwitterReaderTest(TestCase):
         "add_request_date_to_report": None,
         "start_date": datetime(2020, 1, 1),
         "end_date": datetime(2020, 1, 3),
+        "date_range": None,
     }
 
     @mock.patch.object(Client, "__init__", lambda *args: None)
@@ -158,18 +159,8 @@ class TwitterReaderTest(TestCase):
         raw_analytics_response = {
             "time_series_length": 1,
             "data": [
-                {
-                    "id": "XXXXX",
-                    "id_data": [
-                        {"segment": None, "metrics": {"retweets": [11], "likes": [12]}}
-                    ],
-                },
-                {
-                    "id": "YYYYY",
-                    "id_data": [
-                        {"segment": None, "metrics": {"retweets": [21], "likes": [22]}}
-                    ],
-                },
+                {"id": "XXXXX", "id_data": [{"segment": None, "metrics": {"retweets": [11], "likes": [12]}}]},
+                {"id": "YYYYY", "id_data": [{"segment": None, "metrics": {"retweets": [21], "likes": [22]}}]},
             ],
         }
         output = TwitterReader(**temp_kwargs).parse(raw_analytics_response)
@@ -194,30 +185,8 @@ class TwitterReaderTest(TestCase):
         raw_analytics_response = {
             "time_series_length": 3,
             "data": [
-                {
-                    "id": "XXXXX",
-                    "id_data": [
-                        {
-                            "segment": None,
-                            "metrics": {
-                                "retweets": [11, 12, 13],
-                                "likes": [14, 15, 16],
-                            },
-                        }
-                    ],
-                },
-                {
-                    "id": "YYYYY",
-                    "id_data": [
-                        {
-                            "segment": None,
-                            "metrics": {
-                                "retweets": [21, 22, 23],
-                                "likes": [24, 25, 26],
-                            },
-                        }
-                    ],
-                },
+                {"id": "XXXXX", "id_data": [{"segment": None, "metrics": {"retweets": [11, 12, 13], "likes": [14, 15, 16]}}]},
+                {"id": "YYYYY", "id_data": [{"segment": None, "metrics": {"retweets": [21, 22, 23], "likes": [24, 25, 26]}}]},
             ],
         }
         output = TwitterReader(**temp_kwargs).parse(raw_analytics_response)
@@ -244,27 +213,15 @@ class TwitterReaderTest(TestCase):
                 {
                     "id": "XXXXX",
                     "id_data": [
-                        {
-                            "segment": {"segment_name": "Male"},
-                            "metrics": {"retweets": [11], "likes": [12]},
-                        },
-                        {
-                            "segment": {"segment_name": "Female"},
-                            "metrics": {"retweets": [13], "likes": [14]},
-                        },
+                        {"segment": {"segment_name": "Male"}, "metrics": {"retweets": [11], "likes": [12]}},
+                        {"segment": {"segment_name": "Female"}, "metrics": {"retweets": [13], "likes": [14]}},
                     ],
                 },
                 {
                     "id": "YYYYY",
                     "id_data": [
-                        {
-                            "segment": {"segment_name": "Male"},
-                            "metrics": {"retweets": [21], "likes": [22]},
-                        },
-                        {
-                            "segment": {"segment_name": "Female"},
-                            "metrics": {"retweets": [23], "likes": [24]},
-                        },
+                        {"segment": {"segment_name": "Male"}, "metrics": {"retweets": [21], "likes": [22]}},
+                        {"segment": {"segment_name": "Female"}, "metrics": {"retweets": [23], "likes": [24]}},
                     ],
                 },
             ],
@@ -316,9 +273,7 @@ class TwitterReaderTest(TestCase):
 
     @mock.patch.object(Client, "__init__", lambda *args: None)
     @mock.patch.object(Client, "accounts", lambda *args: None)
-    @mock.patch.object(
-        TwitterReader, "get_active_entity_ids", lambda *args: ["XXXXX", "YYYYYY"]
-    )
+    @mock.patch.object(TwitterReader, "get_active_entity_ids", lambda *args: ["XXXXX", "YYYYYY"])
     @mock.patch.object(TwitterReader, "get_job_ids", lambda *args: ["123456789"])
     @mock.patch.object(TwitterReader, "get_job_result", mock_get_job_result)
     @mock.patch.object(TwitterReader, "get_raw_analytics_response", lambda *args: {})

--- a/tests/utils/test_date_handler.py
+++ b/tests/utils/test_date_handler.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import date
+from datetime import date, datetime
 
 from freezegun import freeze_time
 from nck.utils.date_handler import (
@@ -79,9 +79,9 @@ class TestDateHandler(unittest.TestCase):
 
     @freeze_time("2021-02-11")
     def test_build_date_range_without_dates(self):
-        self.assertTupleEqual(build_date_range(None, None, "PREVIOUS_MONTH"), (date(2021, 1, 1), date(2021, 1, 31)))
+        self.assertTupleEqual(build_date_range(None, None, "PREVIOUS_MONTH"), (datetime(2021, 1, 1), datetime(2021, 1, 31)))
 
     def test_build_date_range_with_dates(self):
         self.assertTupleEqual(
-            build_date_range(date(2021, 1, 1), date(2021, 1, 31), None), (date(2021, 1, 1), date(2021, 1, 31))
+            build_date_range(datetime(2021, 1, 1), datetime(2021, 1, 31), None), (datetime(2021, 1, 1), datetime(2021, 1, 31))
         )

--- a/tests/utils/test_date_handler.py
+++ b/tests/utils/test_date_handler.py
@@ -7,7 +7,7 @@ from nck.utils.date_handler import (
     get_date_start_and_date_stop_from_date_range,
     build_date_range,
 )
-from nck.utils.exceptions import InconsistentDateDefinitionException, MissingDateDefinitionException, NoDateDefinitionException
+from nck.utils.exceptions import DateDefinitionException
 from parameterized import parameterized
 
 

--- a/tests/utils/test_date_handler.py
+++ b/tests/utils/test_date_handler.py
@@ -2,7 +2,11 @@ import unittest
 from datetime import date
 
 from freezegun import freeze_time
-from nck.utils.date_handler import check_date_range_definition_conformity, get_date_start_and_date_stop_from_date_range
+from nck.utils.date_handler import (
+    check_date_range_definition_conformity,
+    get_date_start_and_date_stop_from_date_range,
+    build_date_range,
+)
 from nck.utils.exceptions import InconsistentDateDefinitionException, MissingDateDefinitionException, NoDateDefinitionException
 from parameterized import parameterized
 
@@ -72,3 +76,12 @@ class TestDateHandler(unittest.TestCase):
     @parameterized.expand([(date(2021, 1, 12), date(2021, 1, 31), None), (None, None, "YESTERDAY")])
     def test_check_date_range_definition_conformity(self, start_date, end_date, date_range):
         self.assertIsNone(check_date_range_definition_conformity(start_date, end_date, date_range))
+
+    @freeze_time("2021-02-11")
+    def test_build_date_range_without_dates(self):
+        self.assertTupleEqual(build_date_range(None, None, "PREVIOUS_MONTH"), (date(2021, 1, 1), date(2021, 1, 31)))
+
+    def test_build_date_range_with_dates(self):
+        self.assertTupleEqual(
+            build_date_range(date(2021, 1, 1), date(2021, 1, 31), None), (date(2021, 1, 1), date(2021, 1, 31))
+        )


### PR DESCRIPTION
### Issue

- My PR addresses the following Issue: #96 

### Description

- add a build_date_range function in `nck/utils/date_handler.py` to manage optional date range when needed in a reader
- modify `nck/readers/adobe_reader_2_0.py` to use this new function instead of a built-in one
- add tests for this new function and adapt an existing test for adobe reader 2.0

### Tests

My PR adds the following unit tests:
- `nck/utils/test_date_handler.py` create `test_build_date_range_without_dates` to test the build_data_range function only with a date range
- `nck/utils/test_date_handler.py` create `test_build_date_range_with_dates` to test the build_data_range function only with dates
- `nck/readers/test_adobe_reader_2_0.py:` modify `test_build_date_range` to `test_format_date_range` after changing the function