### PR TITLE
Enh: upgrade Twitter Ads API version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ uritemplate==3.0.0
 urllib3==1.25.7
 Werkzeug==0.16.0
 googleads==22.0.0
-twitter-ads==7.0.1
+twitter-ads==8.0.0
 pyjwt==1.7.1
 cryptography==3.3.2
 bs4==0.0.1


### PR DESCRIPTION
Twitter Ads API v7 will stop working on March 2nd: therefore, I upgraded our requirements to Twitter Ads API v8. The API upgrade does not impact any of the reports we are currently using (FYI, you can find the list of changes [on this page](https://twittercommunity.com/t/ads-api-version-8/141914?utm_campaign=ADS_PU_GBL_EN_v7%20Sunset_Reminder%203_210225&utm_medium=email&utm_source=Eloqua&ref=)).