### PR TITLE
Enh: standardize field name normalization

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -129,7 +129,7 @@ NCK commands can be broken down into 3 parts:
 
 .. code-block:: shell
 
-    read_ga --ga-client-id <CLIENT_ID> --ga-client-secret <CLIENT_SECRET> --ga-view-id <VIEW_ID> --ga-refresh-token <REFRESH_TOKEN> --ga-dimension ga:date --ga-metric sessions --ga-metric ga:pageviews --ga-metric ga:bounces --ga-start-date 2020-01-01 --ga-end-date 2020-01-03
+    read_ga --ga-client-id <CLIENT_ID> --ga-client-secret <CLIENT_SECRET> --ga-view-id <VIEW_ID> --ga-refresh-token <REFRESH_TOKEN> --ga-dimension ga:date --ga-metric ga:sessions --ga-metric ga:pageviews --ga-metric ga:bounces --ga-start-date 2020-01-01 --ga-end-date 2020-01-03
 
 3. A writer command, and its options: in the below example, we are writing the output .nsjon stream into a Google Cloud Storage blob named ``google_analytics_report_2020-01-01.njson``, located under the Google Cloud Storage bucket ``nck_extracts``, with the path ``FR/google_analytics/``.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -151,6 +151,18 @@ You can now execute it into your terminal.
 
 **Now that you understand how NCK commands are structured, you can follow these links to find the full documentation on available** :ref:`readers:Readers` and :ref:`writers:Writers`.
 
+=====================
+Normalize field names
+=====================
+
+Some destinations have specific requirements for field names. This is the case of BigQuery, that only accepts letters, digits and underscores.
+
+To normalize field names (i.e. replace any special character or white space by an underscore), you can add the option ``--normalize-keys true`` between ``python nck/entrypoint.py`` and the invocated reader command. If we keep using the previous Google Analytics example, it would give:
+
+.. code-block:: shell
+
+    python nck/entrypoint.py --normalize-keys true read_ga --ga-client-id <CLIENT_ID> --ga-client-secret <CLIENT_SECRET> --ga-view-id <VIEW_ID> --ga-refresh-token <REFRESH_TOKEN> --ga-dimension ga:date --ga-metric sessions --ga-metric ga:pageviews --ga-metric ga:bounces --ga-start-date 2020-01-01 --ga-end-date 2020-01-03 write_console
+
 ==========
 Contribute
 ==========

--- a/docs/source/readers.rst
+++ b/docs/source/readers.rst
@@ -1222,7 +1222,6 @@ Options                         Definition
 ``--ttd-report-schedule-name``  Name of the Report Schedule to create
 ``--ttd-start-date``            Start date of the period to request (format: YYYY-MM-DD)
 ``--ttd-end-date``              End date of the period to request (format: YYYY-MM-DD)
-``--ttd-normalize-stream``      If set to True, yields a NormalizedJSONStream (spaces and special characters replaced by '_' in field names, which is useful for BigQuery). Else (default), yields a standard JSONStream.
 ==============================  ===========================================================================================================================================================================================
 
 If you need any further information, the documentation of The Trade Desk API can be found `here <https://api.thetradedesk.com/v3/portal/api/doc/ApiOverview>`__.

--- a/docs/source/readers.rst
+++ b/docs/source/readers.rst
@@ -234,7 +234,6 @@ Options                             Definition
 ``--confluence-content-type``       Type of content on which the report should be filtered. Possible values: page (default), blog_post.
 ``--confluence-spacekey``           (Optional) Space keys on which the report should be filtered
 ``--confluence-field``              Fields that should be included in the report (path.to.field.value or custom_field)
-``--confluence-normalize-stream``   If set to True, yields a NormalizedJSONStream (spaces and special characters replaced by '_' in field names, which is useful for BigQuery). Else (default), yields a standard JSONStream.
 ==================================  ============================================================================================================================================================================================
 
 Please visit the following two pages for a better understanding of the `Authentification method <https://developer.atlassian.com/cloud/confluence/basic-auth-for-rest-apis/>`__, and of the parameters used in the `Get Content endpoint <https://developer.atlassian.com/cloud/confluence/rest/api-group-content/#api-api-content-get>`__.

--- a/docs/source/readers.rst
+++ b/docs/source/readers.rst
@@ -384,7 +384,7 @@ If Facebook Object Type is...      Facebook Level can be...
 
 .. code-block:: shell
 
-    {"object_story_spec_video_data_call_to_action_value_link": "https://www.artefact.com"}
+    {"object_story_spec[video_data][call_to_action][value][link]": "https://www.artefact.com"}
 
 2.3 Action Breakdown filters can be applied to the fields of Ad Insights Requests using the following syntax: <FIELD_NAME>[<ACTION_BREAKDOWN>:<ACTION_BREAKDOWN_VALUE>]. You can combine multiple Action Breakdown filters on the same field by adding them in cascade next to each other.
 
@@ -422,7 +422,7 @@ If Facebook Object Type is...      Facebook Level can be...
 
 .. code-block:: shell
     
-    {"actions_action_type_video_view": "17", "actions_action_type_post_engagement": "25"}
+    {"actions[action_type:video_view]": "17", "actions[action_type:post_engagement]": "25"}
 
 ==============
 Google Readers

--- a/nck/readers/confluence_reader.py
+++ b/nck/readers/confluence_reader.py
@@ -79,9 +79,7 @@ class ConfluenceReader(Reader):
         ]
         if len(requirements) > 0:
             inter_requirements = (
-                requirements[0]
-                if len(requirements) == 1
-                else list(set(requirements[0]).intersection(*requirements[1:]))
+                requirements[0] if len(requirements) == 1 else list(set(requirements[0]).intersection(*requirements[1:]))
             )
             if len(inter_requirements) == 0:
                 raise ClickException("Invalid request. No intersection found between spacekey requirements.")
@@ -95,9 +93,7 @@ class ConfluenceReader(Reader):
         self.headers = {"Authorization": f"Basic {encoded_string}", "Content-Type": "application/json"}
 
     def _build_params(self):
-        api_fields = [
-            CUSTOM_FIELDS[field]["source_field"] if field in CUSTOM_FIELDS else field for field in self.fields
-        ]
+        api_fields = [CUSTOM_FIELDS[field]["source_field"] if field in CUSTOM_FIELDS else field for field in self.fields]
         return {"type": self.content_type, "expand": ",".join(api_fields)}
 
     def _get_raw_response(self, page_nb, spacekey=None):

--- a/nck/readers/confluence_reader.py
+++ b/nck/readers/confluence_reader.py
@@ -27,7 +27,6 @@ from nck.commands.command import processor
 from nck.readers.reader import Reader
 from nck.helpers.confluence_helper import parse_response, CUSTOM_FIELDS
 from nck.streams.json_stream import JSONStream
-from nck.streams.normalized_json_stream import NormalizedJSONStream
 
 RECORDS_PER_PAGE = 100
 CONTENT_ENDPOINT = "wiki/rest/api/content"
@@ -53,14 +52,6 @@ CONTENT_ENDPOINT = "wiki/rest/api/content"
     required=True,
     multiple=True,
     help="Fields that should be included in the report (path.to.field.value or custom_field)",
-)
-@click.option(
-    "--confluence-normalize-stream",
-    type=click.BOOL,
-    default=False,
-    help="If set to True, yields a NormalizedJSONStream (spaces and special "
-    "characters replaced by '_' in field names, which is useful for BigQuery). "
-    "Else, yields a standard JSONStream.",
 )
 @processor("confluence_user_login", "confluence_api_token")
 def confluence(**kwargs):
@@ -143,7 +134,4 @@ class ConfluenceReader(Reader):
             yield from self._get_report_generator()
 
     def read(self):
-        if self.normalize_stream:
-            yield NormalizedJSONStream("results_", self._get_aggregated_report_generator())
-        else:
-            yield JSONStream("results_", self._get_aggregated_report_generator())
+        yield JSONStream("results_", self._get_aggregated_report_generator())

--- a/nck/readers/dcm_reader.py
+++ b/nck/readers/dcm_reader.py
@@ -16,7 +16,6 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import csv
-import re
 import click
 
 from io import StringIO
@@ -24,12 +23,14 @@ from io import StringIO
 from nck.commands.command import processor
 from nck.readers.reader import Reader
 from nck.utils.args import extract_args
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.clients.dcm_client import DCMClient
 from nck.helpers.dcm_helper import REPORT_TYPES
+from nck.utils.text import strip_prefix
 
 DATEFORMAT = "%Y-%m-%d"
 ENCODING = "utf-8"
+PREFIX = "^dfa:"
 
 
 @click.command(name="read_dcm")
@@ -106,7 +107,8 @@ class DcmReader(Reader):
                 is_main_data = False
 
             if is_main_data:
-                csv_reader = csv.DictReader(StringIO(decoded_row), self.dimensions + self.metrics)
+                formatted_keys = [strip_prefix(key, PREFIX) for key in self.dimensions + self.metrics]
+                csv_reader = csv.DictReader(StringIO(decoded_row), formatted_keys)
                 yield next(csv_reader)
 
     def result_generator(self):
@@ -124,12 +126,4 @@ class DcmReader(Reader):
             yield from self.format_response(report_generator)
 
     def read(self):
-        yield DCMStream("results" + "_".join(self.profile_ids), self.result_generator())
-
-
-class DCMStream(NormalizedJSONStream):
-    DCM_PREFIX = "^dfa:"
-
-    @staticmethod
-    def _normalize_key(key):
-        return re.split(DCMStream.DCM_PREFIX, key)[-1].replace(" ", "_").replace("-", "_")
+        yield JSONStream("results" + "_".join(self.profile_ids), self.result_generator())

--- a/nck/readers/facebook_reader.py
+++ b/nck/readers/facebook_reader.py
@@ -45,7 +45,7 @@ from nck.helpers.facebook_helper import (
     monitor_usage,
 )
 from nck.readers.reader import Reader
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.utils.args import extract_args
 from nck.utils.date_handler import check_date_range_definition_conformity
 from tenacity import retry, stop_after_attempt, stop_after_delay, wait_exponential, wait_none
@@ -427,4 +427,4 @@ class FacebookReader(Reader):
 
     def read(self):
 
-        yield NormalizedJSONStream("results_" + self.object_type + "_" + "_".join(self.object_ids), self.get_data())
+        yield JSONStream("results_" + self.object_type + "_" + "_".join(self.object_ids), self.get_data())

--- a/nck/readers/googleads_reader.py
+++ b/nck/readers/googleads_reader.py
@@ -330,6 +330,4 @@ class GoogleAdsReader(Reader):
         if self.manager_id:
             self.client_customer_ids = self.get_customer_ids(self.manager_id)
 
-        yield JSONStream(
-            "results_" + self.report_name + "_" + "_".join(self.client_customer_ids), self.format_and_yield()
-        )
+        yield JSONStream("results_" + self.report_name + "_" + "_".join(self.client_customer_ids), self.format_and_yield())

--- a/nck/readers/googleads_reader.py
+++ b/nck/readers/googleads_reader.py
@@ -30,7 +30,7 @@ from nck.commands.command import processor
 from nck.config import logger
 from nck.helpers.googleads_helper import DATE_RANGE_TYPE_POSSIBLE_VALUES, ENCODING, REPORT_TYPE_POSSIBLE_VALUES
 from nck.readers.reader import Reader
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.utils.args import extract_args
 from nck.utils.exceptions import InconsistentDateDefinitionException, NoDateDefinitionException
 from nck.utils.retry import retry
@@ -330,6 +330,6 @@ class GoogleAdsReader(Reader):
         if self.manager_id:
             self.client_customer_ids = self.get_customer_ids(self.manager_id)
 
-        yield NormalizedJSONStream(
+        yield JSONStream(
             "results_" + self.report_name + "_" + "_".join(self.client_customer_ids), self.format_and_yield()
         )

--- a/nck/readers/gsheets_reader.py
+++ b/nck/readers/gsheets_reader.py
@@ -22,7 +22,7 @@ from oauth2client.client import GoogleCredentials
 from nck.commands.command import processor
 from nck.readers.reader import Reader
 from nck.utils.args import extract_args
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 
 
 @click.command(name="read_gsheets")
@@ -59,4 +59,4 @@ class GSheetsReader(Reader):
                 for record in worksheet.get_all_records():
                     yield record
 
-            yield NormalizedJSONStream(worksheet.title, result_generator())
+            yield JSONStream(worksheet.title, result_generator())

--- a/nck/readers/mysql_reader.py
+++ b/nck/readers/mysql_reader.py
@@ -21,7 +21,7 @@ import click
 import sqlalchemy
 from nck.readers.reader import Reader
 from nck.commands.command import processor
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.utils.args import extract_args, has_arg, hasnt_arg
 from nck.utils.redis import RedisStateService
 from nck.utils.retry import retry
@@ -155,7 +155,7 @@ class MySQLReader(Reader):
                 row = rows.fetchone()
             rows.close()
 
-        return NormalizedJSONStream(self._name, result_generator())
+        return JSONStream(self._name, result_generator())
 
     def close(self):
         logger.info("Closing MySQL connection")

--- a/nck/readers/objectstorage_reader.py
+++ b/nck/readers/objectstorage_reader.py
@@ -20,7 +20,7 @@ import tempfile
 from nck import config
 from nck.config import logger
 from nck.readers.reader import Reader
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.utils.file_reader import create_file_reader
 
 
@@ -59,7 +59,7 @@ class ObjectStorageReader(Reader):
 
                 name = self.get_key(_object).split("/", self._dest_key_split)[-1]
 
-                yield NormalizedJSONStream(name, self._result_generator(_object))
+                yield JSONStream(name, self._result_generator(_object))
 
     def _result_generator(self, _object):
         with tempfile.TemporaryFile() as temp:

--- a/nck/readers/radarly_reader.py
+++ b/nck/readers/radarly_reader.py
@@ -30,7 +30,7 @@ from collections import OrderedDict
 
 from nck.readers import Reader
 from nck.commands.command import processor
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.utils.retry import retry
 from nck.utils.args import extract_args
 
@@ -49,7 +49,11 @@ class DateRangeSplit(NamedTuple):
 @click.option("--radarly-client-id", required=True, type=click.STRING)
 @click.option("--radarly-client-secret", required=True, type=click.STRING)
 @click.option(
-    "--radarly-focus-id", required=True, multiple=True, type=click.INT, help="Focus IDs (from Radarly queries)",
+    "--radarly-focus-id",
+    required=True,
+    multiple=True,
+    type=click.INT,
+    help="Focus IDs (from Radarly queries)",
 )
 @click.option(
     "--radarly-start-date",
@@ -57,10 +61,15 @@ class DateRangeSplit(NamedTuple):
     type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d %H:%M:%S"]),
 )
 @click.option(
-    "--radarly-end-date", required=True, type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d %H:%M:%S"]),
+    "--radarly-end-date",
+    required=True,
+    type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d %H:%M:%S"]),
 )
 @click.option(
-    "--radarly-api-request-limit", default=250, type=click.INT, help="Max number of posts per API request",
+    "--radarly-api-request-limit",
+    default=250,
+    type=click.INT,
+    help="Max number of posts per API request",
 )
 @click.option(
     "--radarly-api-date-period-limit",
@@ -75,7 +84,10 @@ class DateRangeSplit(NamedTuple):
     help="Max number of posts requested in the window (usually 15 min) (see Radarly documentation)",
 )
 @click.option(
-    "--radarly-api-window", default=300, type=click.INT, help="Duration of the window (usually 300 seconds)",
+    "--radarly-api-window",
+    default=300,
+    type=click.INT,
+    help="Duration of the window (usually 300 seconds)",
 )
 @click.option(
     "--radarly-throttle",
@@ -163,7 +175,7 @@ class RadarlyReader(Reader):
                         ex_type, ex, tb = sys.exc_info()
                         logger.warning(f"Failed to ingest post with error: {ex}. Traceback: {traceback.print_tb(tb)}")
 
-            yield NormalizedJSONStream(name, result_generator())
+            yield JSONStream(name, result_generator())
 
     @retry
     def get_publications_iterator(self, date_range: Tuple[datetime, datetime]):
@@ -220,7 +232,10 @@ class RadarlyReader(Reader):
         else:
 
             date_range_split: DateRangeSplit = self.generate_DateRangeSplit_object(
-                date_range_start=first_date, date_range_end=second_date, posts_count=posts_count, extra_margin=1,
+                date_range_start=first_date,
+                date_range_end=second_date,
+                posts_count=posts_count,
+                extra_margin=1,
             )
             date_ranges_and_posts_volumes: Dict[
                 Tuple[datetime, datetime], int
@@ -239,7 +254,11 @@ class RadarlyReader(Reader):
             return res
 
     def generate_DateRangeSplit_object(
-        self, date_range_start: datetime, date_range_end: datetime, posts_count: int, extra_margin=1,
+        self,
+        date_range_start: datetime,
+        date_range_end: datetime,
+        posts_count: int,
+        extra_margin=1,
     ) -> DateRangeSplit:
 
         delta = date_range_end - date_range_start
@@ -257,7 +276,10 @@ class RadarlyReader(Reader):
         start_date: datetime, end_date: datetime, split_range: float, split_count: int
     ) -> List[Tuple[datetime, datetime]]:
         res = [
-            (start_date + i * timedelta(seconds=split_range), start_date + (i + 1) * timedelta(seconds=split_range),)
+            (
+                start_date + i * timedelta(seconds=split_range),
+                start_date + (i + 1) * timedelta(seconds=split_range),
+            )
             for i in range(split_count - 1)
         ]
         res += [(start_date + (split_count - 1) * timedelta(seconds=split_range), end_date)]

--- a/nck/readers/sa360_reader.py
+++ b/nck/readers/sa360_reader.py
@@ -42,9 +42,7 @@ ENCODING = "utf-8"
     help="If empty, all advertisers from agency will be requested",
 )
 @click.option("--sa360-report-name", default="SA360 Report")
-@click.option(
-    "--sa360-report-type", type=click.Choice(REPORT_TYPES), default=REPORT_TYPES[0]
-)
+@click.option("--sa360-report-type", type=click.Choice(REPORT_TYPES), default=REPORT_TYPES[0])
 @click.option(
     "--sa360-column",
     "sa360_columns",
@@ -80,9 +78,7 @@ class SA360Reader(Reader):
         start_date,
         end_date,
     ):
-        self.sa360_client = SA360Client(
-            access_token, client_id, client_secret, refresh_token
-        )
+        self.sa360_client = SA360Client(access_token, client_id, client_secret, refresh_token)
         self.agency_id = agency_id
         self.advertiser_ids = list(advertiser_ids)
         self.report_name = report_name
@@ -109,17 +105,11 @@ class SA360Reader(Reader):
 
             report_data = self.sa360_client.assert_report_file_ready(report_id)
 
-            for line_iterator in self.sa360_client.download_report_files(
-                report_data, report_id
-            ):
+            for line_iterator in self.sa360_client.download_report_files(report_data, report_id):
                 yield from get_report_generator_from_flat_file(line_iterator)
 
     def read(self):
         if not self.advertiser_ids:
-            self.advertiser_ids = self.sa360_client.get_all_advertisers_of_agency(
-                self.agency_id
-            )
+            self.advertiser_ids = self.sa360_client.get_all_advertisers_of_agency(self.agency_id)
 
-        yield JSONStream(
-            "results" + "_".join(self.advertiser_ids), self.result_generator()
-        )
+        yield JSONStream("results" + "_".join(self.advertiser_ids), self.result_generator())

--- a/nck/readers/sa360_reader.py
+++ b/nck/readers/sa360_reader.py
@@ -19,7 +19,7 @@ import click
 
 from nck.commands.command import processor
 from nck.readers.reader import Reader
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.clients.sa360_client import SA360Client
 from nck.helpers.sa360_helper import REPORT_TYPES
 from nck.utils.args import extract_args
@@ -120,6 +120,6 @@ class SA360Reader(Reader):
                 self.agency_id
             )
 
-        yield NormalizedJSONStream(
+        yield JSONStream(
             "results" + "_".join(self.advertiser_ids), self.result_generator()
         )

--- a/nck/readers/salesforce_reader.py
+++ b/nck/readers/salesforce_reader.py
@@ -23,7 +23,7 @@ import click
 import requests
 from nck.commands.command import processor
 from nck.readers.reader import Reader
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.utils.args import extract_args, has_arg, hasnt_arg
 from nck.utils.redis import RedisStateService
 from nck.utils.retry import retry
@@ -236,12 +236,12 @@ class SalesforceReader(Reader):
                 if self._watermark_column:
                     self._redis_state_service.set(self._name, row[self._watermark_column])
 
-        yield NormalizedJSONStream(self._name, result_generator())
+        yield JSONStream(self._name, result_generator())
 
     @classmethod
     def _clean_record(cls, record):
         """
-            Salesforces records contains metadata which we don't need during ingestion
+        Salesforces records contains metadata which we don't need during ingestion
         """
         return cls._flatten(cls._delete_metadata_from_record(record))
 

--- a/nck/readers/search_console_reader.py
+++ b/nck/readers/search_console_reader.py
@@ -26,7 +26,7 @@ from nck.config import logger
 
 from nck.commands.command import processor
 from nck.readers.reader import Reader
-from nck.streams.normalized_json_stream import NormalizedJSONStream
+from nck.streams.json_stream import JSONStream
 from nck.utils.args import extract_args
 from nck.utils.retry import retry
 
@@ -158,4 +158,4 @@ class SearchConsoleReader(Reader):
                 return None
 
     def read(self):
-        yield NormalizedJSONStream("search_console_results", self.result_generator())
+        yield JSONStream("search_console_results", self.result_generator())

--- a/nck/readers/ttd_reader.py
+++ b/nck/readers/ttd_reader.py
@@ -37,7 +37,10 @@ from nck.utils.text import get_report_generator_from_flat_file
 @click.option("--ttd-login", required=True, help="Login of your API account")
 @click.option("--ttd-password", required=True, help="Password of your API account")
 @click.option(
-    "--ttd-advertiser-id", required=True, multiple=True, help="Advertiser Ids for which report data should be fetched",
+    "--ttd-advertiser-id",
+    required=True,
+    multiple=True,
+    help="Advertiser Ids for which report data should be fetched",
 )
 @click.option(
     "--ttd-report-template-name",
@@ -46,13 +49,21 @@ from nck.utils.text import get_report_generator_from_flat_file
     "can be found within the MyReports section of The Trade Desk UI.",
 )
 @click.option(
-    "--ttd-report-schedule-name", required=True, help="Name of the Report Schedule to create.",
+    "--ttd-report-schedule-name",
+    required=True,
+    help="Name of the Report Schedule to create.",
 )
 @click.option(
-    "--ttd-start-date", required=True, type=click.DateTime(), help="Start date of the period to request (format: YYYY-MM-DD)",
+    "--ttd-start-date",
+    required=True,
+    type=click.DateTime(),
+    help="Start date of the period to request (format: YYYY-MM-DD)",
 )
 @click.option(
-    "--ttd-end-date", required=True, type=click.DateTime(), help="End date of the period to request (format: YYYY-MM-DD)",
+    "--ttd-end-date",
+    required=True,
+    type=click.DateTime(),
+    help="End date of the period to request (format: YYYY-MM-DD)",
 )
 @processor("ttd_login", "ttd_password")
 def the_trade_desk(**kwargs):
@@ -145,7 +156,8 @@ class TheTradeDeskReader(Reader):
         self.report_schedule_id = json_response["ReportScheduleId"]
 
     @retry(
-        wait=wait_exponential(multiplier=1, min=60, max=3600), stop=stop_after_delay(36000),
+        wait=wait_exponential(multiplier=1, min=60, max=3600),
+        stop=stop_after_delay(36000),
     )
     def _wait_for_download_url(self):
         report_execution_details = self._get_report_execution_details()
@@ -188,7 +200,7 @@ class TheTradeDeskReader(Reader):
         def result_generator():
             for record in data:
                 yield {k: format_date(v) if k == "Date" else v for k, v in record.items()}
-            
+
         yield JSONStream("results_" + "_".join(self.advertiser_ids), result_generator())
 
         self._delete_report_schedule()

--- a/nck/readers/ttd_reader.py
+++ b/nck/readers/ttd_reader.py
@@ -21,7 +21,6 @@ from nck.utils.args import extract_args
 from nck.commands.command import processor
 from nck.readers.reader import Reader
 from nck.streams.json_stream import JSONStream
-from nck.streams.normalized_json_stream import NormalizedJSONStream
 from nck.helpers.ttd_helper import (
     API_HOST,
     API_ENDPOINTS,
@@ -54,14 +53,6 @@ from nck.utils.text import get_report_generator_from_flat_file
 )
 @click.option(
     "--ttd-end-date", required=True, type=click.DateTime(), help="End date of the period to request (format: YYYY-MM-DD)",
-)
-@click.option(
-    "--ttd-normalize-stream",
-    type=click.BOOL,
-    default=False,
-    help="If set to True, yields a NormalizedJSONStream (spaces and special "
-    "characters replaced by '_' in field names, which is useful for BigQuery). "
-    "Else, yields a standard JSONStream.",
 )
 @processor("ttd_login", "ttd_password")
 def the_trade_desk(**kwargs):
@@ -197,10 +188,7 @@ class TheTradeDeskReader(Reader):
         def result_generator():
             for record in data:
                 yield {k: format_date(v) if k == "Date" else v for k, v in record.items()}
-
-        if self.normalize_stream:
-            yield NormalizedJSONStream("results_" + "_".join(self.advertiser_ids), result_generator())
-        else:
-            yield JSONStream("results_" + "_".join(self.advertiser_ids), result_generator())
+            
+        yield JSONStream("results_" + "_".join(self.advertiser_ids), result_generator())
 
         self._delete_report_schedule()

--- a/nck/utils/text.py
+++ b/nck/utils/text.py
@@ -24,7 +24,12 @@ from itertools import islice
 
 
 def get_report_generator_from_flat_file(
-    line_iterator, delimiter=",", skip_n_first=0, skip_n_last=0, add_column=False, column_dict={},
+    line_iterator,
+    delimiter=",",
+    skip_n_first=0,
+    skip_n_last=0,
+    add_column=False,
+    column_dict={},
 ):
     """
     From the line iterator of a flat file:
@@ -82,7 +87,13 @@ def decode_if_needed(line):
 
 def parse_decoded_line(line, delimiter=",", quotechar='"'):
     line_as_file = StringIO(line)
-    reader = csv.reader(line_as_file, delimiter=delimiter, quotechar=quotechar, quoting=csv.QUOTE_ALL, skipinitialspace=True,)
+    reader = csv.reader(
+        line_as_file,
+        delimiter=delimiter,
+        quotechar=quotechar,
+        quoting=csv.QUOTE_ALL,
+        skipinitialspace=True,
+    )
     return next(reader)
 
 
@@ -121,3 +132,7 @@ def reformat_naming_for_bq(text, char="_"):
     text = re.sub(r"[\s\W]+", char, text)
     text = re.sub(r"[" + char + "]+", char, text.strip())
     return text.lower()
+
+
+def strip_prefix(text, prefix):
+    return re.split(prefix, text)[-1]

--- a/tests/readers/test_ga_reader.py
+++ b/tests/readers/test_ga_reader.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from unittest import TestCase, mock
 from click import ClickException
 
-from nck.readers.ga_reader import GaReader, GaStream
+from nck.readers.ga_reader import GaReader
 
 
 class GaReaderTest(TestCase):
@@ -28,13 +28,6 @@ class GaReaderTest(TestCase):
     def mock_ga_reader(self, **kwargs):
         for param, value in kwargs.items():
             setattr(self, param, value)
-
-    def test_normalized_ga_stream(self):
-        rows = [{"ga:date": 0, "ga:dimension": "dim", "ga:metric": "met"}, {"ga:date-date": 0}, {"ga:date date": 0}]
-        expected = [{"date": 0, "dimension": "dim", "metric": "met"}, {"date_date": 0}, {"date_date": 0}]
-        ga_stream = GaStream("stream", iter(rows))
-        for row, output in zip(ga_stream.readlines(), iter(expected)):
-            assert row == output
 
     def test_format_date(self):
         test_date = "20190101"
@@ -60,7 +53,7 @@ class GaReaderTest(TestCase):
             "start_date": datetime(2019, 1, 1),
             "view_ids": ["0", "1"],
             "end_date": datetime(2019, 1, 1),
-            "add_view": False
+            "add_view": False,
         }
         reader = GaReader(**kwargs)
         kwargs["add_view"] = True
@@ -98,8 +91,10 @@ class GaReaderTest(TestCase):
             mock_query.return_value = format_data_return_value
 
             expected = [
-                {"date": "2019-01-01", "users": "2"}, {"date": "2019-01-01", "newUsers": "1"},
-                {"date": "2019-01-01", "users": "2"}, {"date": "2019-01-01", "newUsers": "1"}
+                {"date": "2019-01-01", "users": "2"},
+                {"date": "2019-01-01", "newUsers": "1"},
+                {"date": "2019-01-01", "users": "2"},
+                {"date": "2019-01-01", "newUsers": "1"},
             ]
 
             for data in reader.read():
@@ -113,7 +108,7 @@ class GaReaderTest(TestCase):
                 {"viewId": "0", "date": "2019-01-01", "users": "2"},
                 {"viewId": "0", "date": "2019-01-01", "newUsers": "1"},
                 {"viewId": "1", "date": "2019-01-01", "users": "2"},
-                {"viewId": "1", "date": "2019-01-01", "newUsers": "1"}
+                {"viewId": "1", "date": "2019-01-01", "newUsers": "1"},
             ]
 
             for data in reader_with_view_id.read():

--- a/tests/readers/test_ttd.py
+++ b/tests/readers/test_ttd.py
@@ -185,7 +185,7 @@ class TheTradeDeskReaderTest(TestCase):
             ]
         ),
     )
-    def test_read_if_normalize_stream_is_False(self, mock_build_headers, mock_retry, mock_download_report):
+    def test_read(self, mock_build_headers, mock_retry, mock_download_report):
         reader = TheTradeDeskReader(**self.kwargs)
         reader.report_template_id = 1234
         reader.report_schedule_id = 5678
@@ -195,49 +195,6 @@ class TheTradeDeskReaderTest(TestCase):
             {"Date": "2020-01-01", "Advertiser ID": "XXXXX", "Impressions": 10},
             {"Date": "2020-02-01", "Advertiser ID": "XXXXX", "Impressions": 11},
             {"Date": "2020-02-03", "Advertiser ID": "XXXXX", "Impressions": 12},
-        ]
-        for output_record, expected_record in zip(output.readlines(), iter(expected)):
-            self.assertEqual(output_record, expected_record)
-
-    @mock.patch("nck.readers.ttd_reader.TheTradeDeskReader._build_headers", return_value={})
-    @mock.patch("tenacity.BaseRetrying.wait", side_effect=lambda *args, **kwargs: 0)
-    @mock.patch.object(TheTradeDeskReader, "_get_report_template_id", lambda *args: None)
-    @mock.patch.object(TheTradeDeskReader, "_create_report_schedule", lambda *args: None)
-    @mock.patch.object(TheTradeDeskReader, "_wait_for_download_url", lambda *args: None)
-    @mock.patch(
-        "nck.readers.ttd_reader.TheTradeDeskReader._download_report",
-        return_value=iter(
-            [
-                {
-                    "Date": "2020-01-01T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 10,
-                },
-                {
-                    "Date": "2020-02-01T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 11,
-                },
-                {
-                    "Date": "2020-02-03T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 12,
-                },
-            ]
-        ),
-    )
-    def test_read_if_normalize_stream_is_True(self, mock_build_headers, mock_retry, mock_download_report):
-        temp_kwargs = self.kwargs.copy()
-        temp_kwargs.update({"normalize_stream": True})
-        reader = TheTradeDeskReader(**temp_kwargs)
-        reader.report_template_id = 1234
-        reader.report_schedule_id = 5678
-        reader.download_url = "https://download.url"
-        output = next(reader.read())
-        expected = [
-            {"Date": "2020-01-01", "Advertiser_ID": "XXXXX", "Impressions": 10},
-            {"Date": "2020-02-01", "Advertiser_ID": "XXXXX", "Impressions": 11},
-            {"Date": "2020-02-03", "Advertiser_ID": "XXXXX", "Impressions": 12},
         ]
         for output_record, expected_record in zip(output.readlines(), iter(expected)):
             self.assertEqual(output_record, expected_record)

--- a/tests/readers/test_ttd.py
+++ b/tests/readers/test_ttd.py
@@ -33,7 +33,7 @@ class TheTradeDeskReaderTest(TestCase):
         "report_schedule_name": "adgroup_performance_schedule",
         "start_date": datetime(2020, 1, 1),
         "end_date": datetime(2020, 3, 1),
-        "normalize_stream": False
+        "normalize_stream": False,
     }
 
     @mock.patch("nck.readers.ttd_reader.TheTradeDeskReader._build_headers", return_value={})
@@ -60,9 +60,7 @@ class TheTradeDeskReaderTest(TestCase):
             "ResultCount": 1,
         },
     )
-    def test_get_report_template_id_if_exactly_1_match(
-        self, mock_build_headers, mock_api_call
-    ):
+    def test_get_report_template_id_if_exactly_1_match(self, mock_build_headers, mock_api_call):
         reader = TheTradeDeskReader(**self.kwargs)
         reader._get_report_template_id()
         self.assertEqual(reader.report_template_id, 1234)
@@ -90,9 +88,7 @@ class TheTradeDeskReaderTest(TestCase):
             "ResultCount": 2,
         },
     )
-    def test_get_report_template_id_if_more_than_1_match(
-        self, mock_build_headers, mock_api_call
-    ):
+    def test_get_report_template_id_if_more_than_1_match(self, mock_build_headers, mock_api_call):
         with self.assertRaises(Exception):
             TheTradeDeskReader(**self.kwargs)._get_report_template_id()
 
@@ -101,9 +97,7 @@ class TheTradeDeskReaderTest(TestCase):
         "nck.readers.ttd_reader.TheTradeDeskReader._make_api_call",
         return_value={"Result": [], "ResultCount": 0},
     )
-    def test_get_report_template_id_if_no_match(
-        self, mock_build_headers, mock_api_call
-    ):
+    def test_get_report_template_id_if_no_match(self, mock_build_headers, mock_api_call):
         with self.assertRaises(Exception):
             TheTradeDeskReader(**self.kwargs)._get_report_template_id()
 
@@ -167,21 +161,9 @@ class TheTradeDeskReaderTest(TestCase):
         "nck.readers.ttd_reader.TheTradeDeskReader._download_report",
         return_value=iter(
             [
-                {
-                    "Date": "2020-01-01T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 10
-                },
-                {
-                    "Date": "2020-02-01T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 11
-                },
-                {
-                    "Date": "2020-02-03T00:00:00",
-                    "Advertiser ID": "XXXXX",
-                    "Impressions": 12
-                },
+                {"Date": "2020-01-01T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 10},
+                {"Date": "2020-02-01T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 11},
+                {"Date": "2020-02-03T00:00:00", "Advertiser ID": "XXXXX", "Impressions": 12},
             ]
         ),
     )


### PR DESCRIPTION
:heavy_exclamation_mark: **If we merge this PR into dev, you will need to slightly update the commands you are sending to NCK. Please read carefully the below description to warn me if these changes cannot be easily implemented in the context of your project.**

### Issue

This PR addresses Issue #103.

### Description

Two methods were coexisting to normalize field names. By normalizing, I mean replacing any special character or white space by an underscore, to match destination requirements (e.g. BigQuery that only accepts field names containing letters, digits or underscores).

These 2 methods are detailed below:

- Field names could be normalized **at the click group level**, with the click option `--normalize-keys`:
```
python nck/entrypoint.py --normalize-keys true <READER_COMMAND> <WRITER_COMMAND>
```
- Field names could be normalized **at the reader level**, either explicitly or implicitly:
   - Explicitly: when a click option `--normalize-stream` is implemented (keys are normalized only when the user asks it)
   - Implicitly: when a `NormalizedJSONStream` is implemented (keys are normalized in any case)

This PR harmonizes normalization behaviors, implementing the following standard:
- Field names can be normalized at the click group level only
- All readers are returning a `JSONStream`

### How this change affects the commands you are providing to the application

This change affects the following readers:
- Confluence
- DCM
- Facebook
- Google Analytics
- Google Ads
- Google Sheets
- Google Cloud Storage
- MySQL
- Radarly
- Amazon S3
- Salesforce
- SA360
- Search Console
- The Trade Desk

If you are using any of these and want to keep your output data under the same format, you should add the `--normalize-keys` option to the command you are providing to the application. I.e.:

If currently, you are calling the application with:
```
python nck/entrypoint.py <READER_COMMAND> <WRITER_COMMAND>
```
Now, you should now call the application with:
```
python nck/entrypoint.py --normalize-keys true <READER_COMMAND> <WRITER_COMMAND>
```

And if you are querying Confluence or The Trade Desk:
You should also remove the `--normalize-stream true` option from your reader command.

I know that @bibimorlet is already using the `--normalize-keys` option at the click group level on some sources, so he should be able to replicate this configuration easily. My concerns are more about Sanofi: @tom-grivaud, would you be able easily to integrate this configuration to your command generator? If it implies too many changes from your side, we can of course discuss it together first to see the pros and cons.