### PR TITLE
fix: adapt new func names

### DIFF
--- a/nck/utils/file_reader.py
+++ b/nck/utils/file_reader.py
@@ -32,7 +32,7 @@ def unzip(input_file, output_path):
 def sdf_to_njson_generator(path_to_file):
     csv_reader = CSVReader(csv_delimiter=",", csv_fieldnames=None)
     with open(path_to_file, "rb") as fd:
-        dict_reader = csv_reader.read_csv(fd)
+        dict_reader = csv_reader.read(fd)
         for line in dict_reader:
             yield line
 


### PR DESCRIPTION
Just adapt the name of the function according to the recent edits. The new name was just not applied to sdf_to_nsjon...

Interrogation about a possible improvement:
Makes me think about something, what about including checks in CI to test the full pipeline ? I know it will take time but maybe it would only be necessary to merge from dev to a new "master/main" branch. I haven't thought about all the details about this kind CI checks but it could avoid us using version of NCK in which don't work... I had to made test manually and correct these to make sure the new NCK we're going to use would work, I think this kind of feature could be an interesting improvement.

If you guys agree and if you think this is doable I will write a new issue.