### PR TITLE
[WIP] Enh: refactoring repo organization

### DIFF
--- a/nck/readers/__init__.py
+++ b/nck/readers/__init__.py
@@ -32,14 +32,16 @@ from nck.readers.dbm_reader import dbm
 from nck.readers.dcm_reader import dcm
 from nck.readers.ga_reader import ga
 from nck.readers.search_console_reader import search_console
-from nck.readers.adobe_reader import adobe
-from nck.readers.adobe_reader_2_0 import adobe_2_0
 from nck.readers.radarly_reader import radarly
 from nck.readers.yandex_campaign_reader import yandex_campaigns
 from nck.readers.yandex_statistics_reader import yandex_statistics
 from nck.readers.gs_reader import google_sheets
 from nck.readers.confluence_reader import confluence
 from nck.readers.mytarget_reader import mytarget
+
+from nck.readers.adobe.cli import adobe
+from nck.readers.adobe_2_0.cli import adobe_2_0
+
 
 readers = [
     mysql,

--- a/nck/readers/adobe/cli.py
+++ b/nck/readers/adobe/cli.py
@@ -1,0 +1,82 @@
+# GNU Lesser General Public License v3.0 only
+# Copyright (C) 2020 Artefact
+# licence-information@artefact.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import click
+from nck.commands.command import processor
+from nck.readers.adobe.reader import AdobeReader
+from nck.utils.args import extract_args
+
+
+def format_key_if_needed(ctx, param, value):
+    """
+    In some cases, newlines are escaped when passed as a click.option().
+    This callback corrects this unexpected behaviour.
+    """
+    return value.replace("\\n", "\n")
+
+
+@click.command(name="read_adobe")
+@click.option(
+    "--adobe-client-id",
+    required=True,
+    help="Client ID, that you can find in your integration section on Adobe Developper Console.",
+)
+@click.option(
+    "--adobe-client-secret",
+    required=True,
+    help="Client Secret, that you can find in your integration section on Adobe Developper Console.",
+)
+@click.option(
+    "--adobe-tech-account-id",
+    required=True,
+    help="Technical Account ID, that you can find in your integration section on Adobe Developper Console.",
+)
+@click.option(
+    "--adobe-org-id",
+    required=True,
+    help="Organization ID, that you can find in your integration section on Adobe Developper Console.",
+)
+@click.option(
+    "--adobe-private-key",
+    required=True,
+    callback=format_key_if_needed,
+    help="Content of the private.key file, that you had to provide to create the integration. "
+    "Make sure to enter the parameter in quotes, include headers, and indicate newlines as '\\n'.",
+)
+@click.option(
+    "--adobe-global-company-id",
+    required=True,
+    help="Global Company ID, to be requested to Discovery API. "
+    "Doc: https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md)",
+)
+@click.option("--adobe-list-report-suite", type=click.BOOL, default=False)
+@click.option("--adobe-report-suite-id")
+@click.option("--adobe-report-element-id", multiple=True)
+@click.option("--adobe-report-metric-id", multiple=True)
+@click.option("--adobe-date-granularity", default=None)
+@click.option(
+    "--adobe-day-range",
+    type=click.Choice(["PREVIOUS_DAY", "LAST_30_DAYS", "LAST_7_DAYS", "LAST_90_DAYS"]),
+    default=None,
+)
+@click.option("--adobe-start-date", type=click.DateTime())
+@click.option("--adobe-end-date", default=None, type=click.DateTime())
+@processor("adobe_password", "adobe_username")
+def adobe(**kwargs):
+    # Should handle valid combinations dimensions/metrics in the API
+    return AdobeReader(**extract_args("adobe_", kwargs))

--- a/nck/readers/adobe/config.py
+++ b/nck/readers/adobe/config.py
@@ -1,0 +1,21 @@
+# GNU Lesser General Public License v3.0 only
+# Copyright (C) 2020 Artefact
+# licence-information@artefact.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ADOBE_API_ENDPOINT = "https://api.omniture.com/admin/1.4/rest/"
+LIMIT_NVIEWS_PER_REQ = 5
+MAX_WAIT_REPORT_DELAY = 4096

--- a/nck/readers/adobe/helper.py
+++ b/nck/readers/adobe/helper.py
@@ -15,14 +15,27 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# Credit goes to Mr Martin Winkel for the base code provided :
+# github : https://github.com/SaturnFromTitan/adobe_analytics
+
 import datetime
+
 import more_itertools
 from nck.config import logger
 from nck.utils.text import reformat_naming_for_bq
 
 
-# Credit goes to Mr Martin Winkel for the base code provided :
-# github : https://github.com/SaturnFromTitan/adobe_analytics
+class ReportDescriptionError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        logger.error(message)
+
+
+class ReportNotReadyError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        logger.error(message)
 
 
 def _parse_header(report):
@@ -103,7 +116,12 @@ def _dimension_value_is_nan(chunk):
 
 
 def _to_datetime(chunk):
-    time_stamp = datetime.datetime(year=chunk["year"], month=chunk["month"], day=chunk["day"], hour=chunk.get("hour", 0),)
+    time_stamp = datetime.datetime(
+        year=chunk["year"],
+        month=chunk["month"],
+        day=chunk["day"],
+        hour=chunk.get("hour", 0),
+    )
     return time_stamp.strftime("%Y-%m-%d %H:00:00")
 
 
@@ -120,15 +138,3 @@ def parse(raw_response):
                 yield {headers[i]: row[i] for i in range(len(headers))}
             else:
                 yield {header: None for header in headers}
-
-
-class ReportDescriptionError(Exception):
-    def __init__(self, message):
-        super().__init__(message)
-        logger.error(message)
-
-
-class ReportNotReadyError(Exception):
-    def __init__(self, message):
-        super().__init__(message)
-        logger.error(message)

--- a/nck/readers/adobe_2_0/cli.py
+++ b/nck/readers/adobe_2_0/cli.py
@@ -1,0 +1,112 @@
+# GNU Lesser General Public License v3.0 only
+# Copyright (C) 2020 Artefact
+# licence-information@artefact.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import click
+from nck.commands.command import processor
+from nck.readers.adobe_2_0.reader import AdobeReader_2_0
+from nck.utils.args import extract_args
+from nck.utils.date_handler import DEFAULT_DATE_RANGE_FUNCTIONS
+
+
+def format_key_if_needed(ctx, param, value):
+    """
+    In some cases, newlines are escaped when passed as a click.option().
+    This callback corrects this unexpected behaviour.
+    """
+    return value.replace("\\n", "\n")
+
+
+@click.command(name="read_adobe_2_0")
+@click.option(
+    "--adobe-2-0-client-id",
+    required=True,
+    help="Client ID, that you can find in your integration section on Adobe Developper Console.",
+)
+@click.option(
+    "--adobe-2-0-client-secret",
+    required=True,
+    help="Client Secret, that you can find in your integration section on Adobe Developper Console.",
+)
+@click.option(
+    "--adobe-2-0-tech-account-id",
+    required=True,
+    help="Technical Account ID, that you can find in your integration section on Adobe Developper Console.",
+)
+@click.option(
+    "--adobe-2-0-org-id",
+    required=True,
+    help="Organization ID, that you can find in your integration section on Adobe Developper Console.",
+)
+@click.option(
+    "--adobe-2-0-private-key",
+    required=True,
+    callback=format_key_if_needed,
+    help="Content of the private.key file, that you had to provide to create the integration. "
+    "Make sure to enter the parameter in quotes, include headers, and indicate newlines as '\\n'.",
+)
+@click.option(
+    "--adobe-2-0-global-company-id",
+    required=True,
+    help="Global Company ID, to be requested to Discovery API. "
+    "Doc: https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md)",
+)
+@click.option(
+    "--adobe-2-0-report-suite-id",
+    required=True,
+    help="ID of the requested Adobe Report Suite",
+)
+@click.option(
+    "--adobe-2-0-dimension",
+    required=True,
+    multiple=True,
+    help="To get dimension names, enable the Debugger feature in Adobe Analytics Workspace: "
+    "it will allow you to visualize the back-end JSON requests made by Adobe Analytics UI to Reporting API 2.0. "
+    "Doc: https://github.com/AdobeDocs/analytics-2.0-apis/blob/master/reporting-tricks.md",
+)
+@click.option(
+    "--adobe-2-0-metric",
+    required=True,
+    multiple=True,
+    help="To get metric names, enable the Debugger feature in Adobe Analytics Workspace: "
+    "it will allow you to visualize the back-end JSON requests made by Adobe Analytics UI to Reporting API 2.0. "
+    "Doc: https://github.com/AdobeDocs/analytics-2.0-apis/blob/master/reporting-tricks.md",
+)
+@click.option(
+    "--adobe-2-0-start-date",
+    type=click.DateTime(),
+    help="Start date of the report",
+)
+@click.option(
+    "--adobe-2-0-end-date",
+    type=click.DateTime(),
+    help="End date of the report",
+)
+@click.option(
+    "--adobe-2-0-date-range",
+    type=click.Choice(DEFAULT_DATE_RANGE_FUNCTIONS.keys()),
+    help=f"One of the available NCK default date ranges: {DEFAULT_DATE_RANGE_FUNCTIONS.keys()}",
+)
+@processor(
+    "adobe_2_0_client_id",
+    "adobe_2_0_client_secret",
+    "adobe_2_0_tech_account_id",
+    "adobe_2_0_org_id",
+    "adobe_2_0_private_key",
+)
+def adobe_2_0(**kwargs):
+    return AdobeReader_2_0(**extract_args("adobe_2_0_", kwargs))

--- a/nck/readers/adobe_2_0/config.py
+++ b/nck/readers/adobe_2_0/config.py
@@ -1,0 +1,21 @@
+# GNU Lesser General Public License v3.0 only
+# Copyright (C) 2020 Artefact
+# licence-information@artefact.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+DATEFORMAT = "%Y-%m-%dT%H:%M:%S"
+API_WINDOW_DURATION = 6
+API_REQUESTS_OVER_WINDOW_LIMIT = 12

--- a/nck/readers/adobe_2_0/helper.py
+++ b/nck/readers/adobe_2_0/helper.py
@@ -16,8 +16,9 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from nck.config import logger
 from datetime import datetime
+
+from nck.config import logger
 
 
 class APIRateLimitError(Exception):

--- a/nck/readers/adobe_2_0/reader.py
+++ b/nck/readers/adobe_2_0/reader.py
@@ -16,18 +16,35 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+# GNU Lesser General Public License v3.0 only
+# Copyright (C) 2020 Artefact
+# licence-information@artefact.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 import json
-from nck.config import logger
 import time
 from datetime import timedelta
 from itertools import chain
 
-import click
 import requests
 from click.exceptions import ClickException
 from nck.clients.adobe_client import AdobeClient
-from nck.commands.command import processor
-from nck.helpers.adobe_helper_2_0 import (
+from nck.config import logger
+from nck.readers.adobe_2_0.config import API_REQUESTS_OVER_WINDOW_LIMIT, API_WINDOW_DURATION, DATEFORMAT
+from nck.readers.adobe_2_0.helper import (
     APIRateLimitError,
     add_metric_container_to_report_description,
     get_item_ids_from_nodes,
@@ -36,96 +53,8 @@ from nck.helpers.adobe_helper_2_0 import (
 )
 from nck.readers.reader import Reader
 from nck.streams.json_stream import JSONStream
-from nck.utils.args import extract_args
-from nck.utils.date_handler import (
-    DEFAULT_DATE_RANGE_FUNCTIONS,
-    check_date_range_definition_conformity,
-    get_date_start_and_date_stop_from_date_range,
-)
+from nck.utils.date_handler import check_date_range_definition_conformity, get_date_start_and_date_stop_from_date_range
 from nck.utils.retry import retry
-
-DATEFORMAT = "%Y-%m-%dT%H:%M:%S"
-API_WINDOW_DURATION = 6
-API_REQUESTS_OVER_WINDOW_LIMIT = 12
-
-
-def format_key_if_needed(ctx, param, value):
-    """
-    In some cases, newlines are escaped when passed as a click.option().
-    This callback corrects this unexpected behaviour.
-    """
-    return value.replace("\\n", "\n")
-
-
-@click.command(name="read_adobe_2_0")
-@click.option(
-    "--adobe-2-0-client-id",
-    required=True,
-    help="Client ID, that you can find in your integration section on Adobe Developper Console.",
-)
-@click.option(
-    "--adobe-2-0-client-secret",
-    required=True,
-    help="Client Secret, that you can find in your integration section on Adobe Developper Console.",
-)
-@click.option(
-    "--adobe-2-0-tech-account-id",
-    required=True,
-    help="Technical Account ID, that you can find in your integration section on Adobe Developper Console.",
-)
-@click.option(
-    "--adobe-2-0-org-id",
-    required=True,
-    help="Organization ID, that you can find in your integration section on Adobe Developper Console.",
-)
-@click.option(
-    "--adobe-2-0-private-key",
-    required=True,
-    callback=format_key_if_needed,
-    help="Content of the private.key file, that you had to provide to create the integration. "
-    "Make sure to enter the parameter in quotes, include headers, and indicate newlines as '\\n'.",
-)
-@click.option(
-    "--adobe-2-0-global-company-id",
-    required=True,
-    help="Global Company ID, to be requested to Discovery API. "
-    "Doc: https://www.adobe.io/apis/experiencecloud/analytics/docs.html#!AdobeDocs/analytics-2.0-apis/master/discovery.md)",
-)
-@click.option(
-    "--adobe-2-0-report-suite-id", required=True, help="ID of the requested Adobe Report Suite",
-)
-@click.option(
-    "--adobe-2-0-dimension",
-    required=True,
-    multiple=True,
-    help="To get dimension names, enable the Debugger feature in Adobe Analytics Workspace: "
-    "it will allow you to visualize the back-end JSON requests made by Adobe Analytics UI to Reporting API 2.0. "
-    "Doc: https://github.com/AdobeDocs/analytics-2.0-apis/blob/master/reporting-tricks.md",
-)
-@click.option(
-    "--adobe-2-0-metric",
-    required=True,
-    multiple=True,
-    help="To get metric names, enable the Debugger feature in Adobe Analytics Workspace: "
-    "it will allow you to visualize the back-end JSON requests made by Adobe Analytics UI to Reporting API 2.0. "
-    "Doc: https://github.com/AdobeDocs/analytics-2.0-apis/blob/master/reporting-tricks.md",
-)
-@click.option(
-    "--adobe-2-0-start-date", type=click.DateTime(), help="Start date of the report",
-)
-@click.option(
-    "--adobe-2-0-end-date", type=click.DateTime(), help="End date of the report",
-)
-@click.option(
-    "--adobe-2-0-date-range",
-    type=click.Choice(DEFAULT_DATE_RANGE_FUNCTIONS.keys()),
-    help=f"One of the available NCK default date ranges: {DEFAULT_DATE_RANGE_FUNCTIONS.keys()}",
-)
-@processor(
-    "adobe_2_0_client_id", "adobe_2_0_client_secret", "adobe_2_0_tech_account_id", "adobe_2_0_org_id", "adobe_2_0_private_key",
-)
-def adobe_2_0(**kwargs):
-    return AdobeReader_2_0(**extract_args("adobe_2_0_", kwargs))
 
 
 class AdobeReader_2_0(Reader):
@@ -186,7 +115,10 @@ class AdobeReader_2_0(Reader):
         }
 
         rep_desc = add_metric_container_to_report_description(
-            rep_desc=rep_desc, dimensions=self.dimensions, metrics=metrics, breakdown_item_ids=breakdown_item_ids,
+            rep_desc=rep_desc,
+            dimensions=self.dimensions,
+            metrics=metrics,
+            breakdown_item_ids=breakdown_item_ids,
         )
 
         return rep_desc

--- a/tests/readers/adobe/test_reader.py
+++ b/tests/readers/adobe/test_reader.py
@@ -15,9 +15,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 import datetime
-from nck.readers.adobe_reader import AdobeReader
 from unittest import TestCase, mock
+
+from nck.readers.adobe.reader import AdobeReader
 
 
 class AdobeReaderTest(TestCase):
@@ -54,14 +56,10 @@ class AdobeReaderTest(TestCase):
 
     @mock.patch("nck.clients.adobe_client.AdobeClient.__init__", return_value=None)
     @mock.patch(
-        "nck.readers.adobe_reader.AdobeReader.query_report",
+        "nck.readers.adobe.reader.AdobeReader.query_report",
         return_value={"reportID": "XXXXX"},
     )
-    @mock.patch(
-        "nck.readers.adobe_reader.AdobeReader.download_report", return_value=None
-    )
-    def test_read_empty_data(
-        self, mock_adobe_client, mock_query_report, mock_download_report
-    ):
+    @mock.patch("nck.readers.adobe.reader.AdobeReader.download_report", return_value=None)
+    def test_read_empty_data(self, mock_adobe_client, mock_query_report, mock_download_report):
         reader = AdobeReader(**self.kwargs)
         self.assertFalse(len(list(reader.read())) > 1)

--- a/tests/readers/adobe_2_0/test_reader.py
+++ b/tests/readers/adobe_2_0/test_reader.py
@@ -16,10 +16,10 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from nck.readers.adobe_reader_2_0 import AdobeReader_2_0
+import datetime
 from unittest import TestCase, mock
 
-import datetime
+from nck.readers.adobe_2_0.reader import AdobeReader_2_0
 
 
 class AdobeReaderTest_2_0(TestCase):
@@ -244,7 +244,7 @@ class AdobeReaderTest_2_0(TestCase):
         ],
     )
     @mock.patch(
-        "nck.readers.adobe_reader_2_0.AdobeReader_2_0.get_parsed_report",
+        "nck.readers.adobe_2_0.reader.AdobeReader_2_0.get_parsed_report",
         side_effect=[
             [
                 {


### PR DESCRIPTION
### Issue

This PR addresses Issue #70.

### Description

The purpose of this PR is to implement the following repo organization:
```
- nck/
-- readers/
--- <source>/
---- reader.py
---- cli.py
---- config.py
---- helper.py
```

For now, I implemented it for `adobe` and `adobe_2_0` readers.
Before I replicate this structure to other readers, could you please confirm that this structure seems relevant to you?
Thank you!

