### PR TITLE
fix date checks and format them

### DIFF
--- a/nck/readers/dbm_reader.py
+++ b/nck/readers/dbm_reader.py
@@ -70,8 +70,6 @@ DISCOVERY_URI = "https://analyticsreporting.googleapis.com/$discovery/rest"
 )
 @click.option(
     "--dbm-day-range",
-    required=True,
-    default="LAST_7_DAYS",
     type=click.Choice(["PREVIOUS_DAY", "LAST_30_DAYS", "LAST_90_DAYS", "LAST_7_DAYS", "PREVIOUS_MONTH", "PREVIOUS_WEEK"]),
 )
 @processor("dbm_access_token", "dbm_refresh_token", "dbm_client_secret")

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -40,18 +40,12 @@ DEFAULT_DATE_RANGE_FUNCTIONS = {
 
 
 def check_date_range_definition_conformity(start_date: date, end_date: date, date_range: str):
-    if (start_date is None and end_date is None) and date_range is None:
-        raise NoDateDefinitionException(
-            "You must at least define a couple \
-                        start-date/end-date or a date-range"
-        )
-    elif (start_date is None or end_date is None) and (start_date is not None or end_date is not None):
-        raise MissingDateDefinitionException("If you define dates, both start_date and end_date must be defined")
-    if start_date is not None and end_date is not None and date_range is not None:
-        raise InconsistentDateDefinitionException(
-            "You must define either start_date and end_date \
-            or date_range, but not both"
-        )
+    if not any([start_date, end_date, date_range]):
+        raise NoDateDefinitionException("You must at least define a couple (start-date, end-date) or a date-range")
+    elif bool(start_date) != bool(end_date):
+        raise MissingDateDefinitionException("Both start_date and end_date must be defined")
+    elif all([start_date, end_date, date_range]):
+        raise InconsistentDateDefinitionException("You must define either (start_date, end_date) or date_range but not both")
 
 
 def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date, date]:

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -40,12 +40,16 @@ DEFAULT_DATE_RANGE_FUNCTIONS = {
 
 
 def check_date_range_definition_conformity(start_date: date, end_date: date, date_range: str):
-    if not any([start_date, end_date, date_range]):
-        raise NoDateDefinitionException("You must at least define a couple (start-date, end-date) or a date-range")
-    elif bool(start_date) != bool(end_date):
+    if bool(start_date) != bool(end_date):
         raise MissingDateDefinitionException("Both start_date and end_date must be defined")
-    elif all([start_date, end_date, date_range]):
-        raise InconsistentDateDefinitionException("You must define either (start_date, end_date) or date_range but not both")
+    if date_range:
+        if all([start_date, end_date]):
+            raise InconsistentDateDefinitionException("You must define either (start_date, end_date) or date_range")
+    else:
+        if not any([start_date, end_date]):
+            raise NoDateDefinitionException("You must at least define a couple (start-date, end-date) or a date-range")
+        elif end_date < start_date:
+            raise InconsistentDateDefinitionException("Report end date should be equal or ulterior to report start date.")
 
 
 def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date, date]:

--- a/nck/utils/date_handler.py
+++ b/nck/utils/date_handler.py
@@ -2,7 +2,7 @@ import calendar
 from datetime import date, timedelta
 from typing import Tuple
 
-from nck.utils.exceptions import InconsistentDateDefinitionException, MissingDateDefinitionException, NoDateDefinitionException
+from nck.utils.exceptions import DateDefinitionException
 
 
 def __get_yesterday_date(current_date: date) -> Tuple[date, date]:
@@ -40,16 +40,15 @@ DEFAULT_DATE_RANGE_FUNCTIONS = {
 
 
 def check_date_range_definition_conformity(start_date: date, end_date: date, date_range: str):
-    if bool(start_date) != bool(end_date):
-        raise MissingDateDefinitionException("Both start_date and end_date must be defined")
+
     if date_range:
-        if all([start_date, end_date]):
-            raise InconsistentDateDefinitionException("You must define either (start_date, end_date) or date_range")
+        if any([start_date, end_date]):
+            raise DateDefinitionException("You must define either (start_date, end_date) or date_range")
     else:
-        if not any([start_date, end_date]):
-            raise NoDateDefinitionException("You must at least define a couple (start-date, end-date) or a date-range")
+        if not all([start_date, end_date]):
+            raise DateDefinitionException("You must at least define a couple (start-date, end-date) or a date-range")
         elif end_date < start_date:
-            raise InconsistentDateDefinitionException("Report end date should be equal or ulterior to report start date.")
+            raise DateDefinitionException("Report end date should be equal or ulterior to report start date.")
 
 
 def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date, date]:

--- a/nck/utils/exceptions.py
+++ b/nck/utils/exceptions.py
@@ -29,6 +29,12 @@ class SdfOperationError(Exception):
     pass
 
 
+class DateDefinitionException(Exception):
+    """Raised when the date parameters are not valid"""
+
+    pass
+
+
 class NoDateDefinitionException(Exception):
     """Raised when no date range or start date/end date is defined"""
 

--- a/tests/utils/test_date_handler.py
+++ b/tests/utils/test_date_handler.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from freezegun import freeze_time
 from nck.utils.date_handler import check_date_range_definition_conformity, get_date_start_and_date_stop_from_date_range
-from nck.utils.exceptions import InconsistentDateDefinitionException, MissingDateDefinitionException, NoDateDefinitionException
+from nck.utils.exceptions import DateDefinitionException
 from parameterized import parameterized
 
 
@@ -58,15 +58,15 @@ class TestDateHandler(unittest.TestCase):
         ]
     )
     def test_check_date_range_definition_conformity_if_missing_date(self, start_date, end_date, date_range):
-        with self.assertRaises(MissingDateDefinitionException):
+        with self.assertRaises(DateDefinitionException):
             check_date_range_definition_conformity(start_date, end_date, date_range)
 
     def test_check_date_range_definition_conformity_if_no_date(self):
-        with self.assertRaises(NoDateDefinitionException):
+        with self.assertRaises(DateDefinitionException):
             check_date_range_definition_conformity(None, None, None)
 
     def test_check_date_range_definition_conformity_if_inconsistent(self):
-        with self.assertRaises(InconsistentDateDefinitionException):
+        with self.assertRaises(DateDefinitionException):
             check_date_range_definition_conformity(date(2021, 1, 12), date(2021, 1, 31), "YESTERDAY")
 
     @parameterized.expand([(date(2021, 1, 12), date(2021, 1, 31), None), (None, None, "YESTERDAY")])


### PR DESCRIPTION
### Issue

- [x] No spotted issue

### Description

Date checks were inconsistent with the reader.
The reader was no longer usable with (start-end, end-date) couple parameters.