### PR TITLE
fix: edit fb version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ colorama==0.4.3
 curlify==2.2.1
 docopt==0.6.2
 docutils==0.15.2
-facebook-business==8.0.5
+facebook-business==10.0.0
 google-api-core==1.14.3
 google-api-python-client==1.4.2
 google-auth==1.28.0


### PR DESCRIPTION
### Description

Our client received the following email to address an issue regarding the version of the fb API. Here is the content:

"Your app will be affected by the deprecation of Marketing API versions prior to v9.0.  Your app xxx, currently accesses a Marketing API version prior to v9.0. We will be deprecating all versions prior to v9.0 on Tuesday, May 4, 2021. To ensure a smooth transition, please migrate all calls to Marketing API v9.0 or higher. We recommend migrating to the most recent version, Marketing API v10.0, to reduce the number of future migrations for developers. Visit our changelog to see all upcoming Marketing API deprecation dates as well as the full list of changes in all versions.You can view this and other Developer Notifications related to your app, in the App Dashboard."

Therefore I changed the version in the requirements and it worked great on the reports I use for my project.

@bibimorlet Let me know if it works with this new version for you as you're using the facebook API.

If you guys know other people using the fb API please let them know that this modification is done and that the changes need to be applied before the 4th of May 2021.