### PR TITLE
Google DCM Reader: run report based on report id

### DIFF
--- a/ack/clients/google_dcm/client.py
+++ b/ack/clients/google_dcm/client.py
@@ -82,9 +82,10 @@ class GoogleDCMClient:
                 else:
                     logger.info(f"Filter not found: {dimension_name} - {dimension_value}")
 
-    def run_report(self, report, profile_id):
-        inserted_report = self._service.reports().insert(profileId=profile_id, body=report).execute()
-        report_id = inserted_report["id"]
+    def run_report(self, report, profile_id, report_id):
+        if not report_id:
+            inserted_report = self._service.reports().insert(profileId=profile_id, body=report).execute()
+            report_id = inserted_report["id"]
         file = self._service.reports().run(profileId=profile_id, reportId=report_id).execute()
         file_id = file["id"]
         return report_id, file_id

--- a/ack/readers/google_dcm/cli.py
+++ b/ack/readers/google_dcm/cli.py
@@ -30,6 +30,7 @@ from ack.utils.processor import processor
 @click.option("--dcm-client-secret", required=True)
 @click.option("--dcm-refresh-token", required=True)
 @click.option("--dcm-profile-id", "dcm_profile_ids", required=True, multiple=True)
+@click.option("--dcm-report-id", "dcm_report_id", default=None)
 @click.option("--dcm-report-name", default="DCM Report")
 @click.option("--dcm-report-type", type=click.Choice(REPORT_TYPES), default=REPORT_TYPES[0])
 @click.option(

--- a/ack/readers/google_dcm/reader.py
+++ b/ack/readers/google_dcm/reader.py
@@ -77,8 +77,7 @@ class GoogleDCMReader(Reader):
         self.dcm_client.add_report_criteria(report, self.start_date, self.end_date, self.metrics, self.dimensions)
 
         for profile_id in self.profile_ids:
-            if not self.report_id:
-                self.dcm_client.add_dimension_filters(report, profile_id, self.filters)
+            self.dcm_client.add_dimension_filters(report, profile_id, self.filters)
 
             report_id, file_id = self.dcm_client.run_report(report, profile_id, self.report_id)
 

--- a/ack/readers/google_dcm/reader.py
+++ b/ack/readers/google_dcm/reader.py
@@ -35,6 +35,7 @@ class GoogleDCMReader(Reader):
         client_secret,
         refresh_token,
         profile_ids,
+        report_id,
         report_name,
         report_type,
         metrics,
@@ -46,6 +47,7 @@ class GoogleDCMReader(Reader):
     ):
         self.dcm_client = GoogleDCMClient(access_token, client_id, client_secret, refresh_token)
         self.profile_ids = list(profile_ids)
+        self.report_id = report_id
         self.report_name = report_name
         self.report_type = report_type
         self.metrics = list(metrics)
@@ -75,9 +77,10 @@ class GoogleDCMReader(Reader):
         self.dcm_client.add_report_criteria(report, self.start_date, self.end_date, self.metrics, self.dimensions)
 
         for profile_id in self.profile_ids:
-            self.dcm_client.add_dimension_filters(report, profile_id, self.filters)
+            if not self.report_id:
+                self.dcm_client.add_dimension_filters(report, profile_id, self.filters)
 
-            report_id, file_id = self.dcm_client.run_report(report, profile_id)
+            report_id, file_id = self.dcm_client.run_report(report, profile_id, self.report_id)
 
             self.dcm_client.assert_report_file_ready(file_id=file_id, report_id=report_id)
 


### PR DESCRIPTION
### Description
The goal of this PR is to give the possibility to run a google dcm report based on a report id instead of creating a new report. 
