### PR TITLE
Fix: google dcm reports taking more than one hour to be ready

### DIFF
--- a/ack/clients/google_dcm/client.py
+++ b/ack/clients/google_dcm/client.py
@@ -89,7 +89,7 @@ class GoogleDCMClient:
         file_id = file["id"]
         return report_id, file_id
 
-    @retry(wait=wait_exponential(multiplier=60, min=60, max=240), stop=stop_after_delay(3600))
+    @retry(wait=wait_exponential(multiplier=60, min=60, max=240), stop=stop_after_delay(36000))
     def assert_report_file_ready(self, report_id, file_id):
         """Poke the report file status"""
         report_file = self._service.files().get(reportId=report_id, fileId=file_id).execute()

--- a/ack/clients/google_dcm/client.py
+++ b/ack/clients/google_dcm/client.py
@@ -109,6 +109,7 @@ class GoogleDCMClient:
 
         if report_file["status"] == "REPORT_AVAILABLE":
             # Create a get request.
+            self.auth = f"{self._credentials.token_response['token_type']} {self._credentials.token_response['access_token']}"
             request = self._service.files().get_media(reportId=report_id, fileId=file_id)
             headers = request.headers
             headers.update({"Authorization": self.auth})


### PR DESCRIPTION
### Description

The goal of this PR is to update the google dcm client so that we can retrieve data when the generation of the report takes more than one hour to be completed. 
To do so:
- I increased the stop after delay parameter in the retry of the function assert_report_file_ready (3600 -> 36000)
- I added a refresh of the authorization header before the download of the report (because access tokens are valid for only one hour and are regenerated when their lifetime expires)