### PR TITLE
modify result_generator Yandex_campaign

### DIFF
--- a/ack/readers/yandex_campaign/reader.py
+++ b/ack/readers/yandex_campaign/reader.py
@@ -36,7 +36,7 @@ class YandexCampaignReader(Reader):
         api_client = ApiClient(self.token, YANDEX_DIRECT_API_BASE_URL)
         request_body = self._build_request_body()
         response = api_client.execute_request(url="campaigns", body=request_body, headers={})
-        if response.json()["result"]:
+        if response.json().get("result", {}):
             yield response.json()
 
     def _build_request_body(self):

--- a/ack/readers/yandex_campaign/reader.py
+++ b/ack/readers/yandex_campaign/reader.py
@@ -36,7 +36,8 @@ class YandexCampaignReader(Reader):
         api_client = ApiClient(self.token, YANDEX_DIRECT_API_BASE_URL)
         request_body = self._build_request_body()
         response = api_client.execute_request(url="campaigns", body=request_body, headers={})
-        yield response.json()
+        if response.json()["result"]:
+            yield response.json()
 
     def _build_request_body(self):
         body = {}


### PR DESCRIPTION
### Description

- The goal of this PR is to modify the yandex_campaign reader in order to return an empty file when the result of the API is the following one: {"result": {}}. 
- For this purpose, I added a check in the result_generator before yielding the API response. 

