### PR TITLE
update api version google dcm

### DIFF
--- a/ack/clients/google_dcm/client.py
+++ b/ack/clients/google_dcm/client.py
@@ -72,6 +72,16 @@ class GoogleDCMClient:
                 "endDate": report["criteria"]["dateRange"]["endDate"],
             }
             values = self._service.dimensionValues().query(profileId=profile_id, body=request).execute()
+            current_values = values
+
+            while current_values["items"]:
+                nextPageToken = current_values["nextPageToken"]
+                current_values = (
+                    self._service.dimensionValues()
+                    .query(profileId=profile_id, body=request, pageToken=nextPageToken)
+                    .execute()
+                )
+                values["items"] += current_values["items"]
 
             report["criteria"]["dimensionFilters"] = report["criteria"].get("dimensionFilters", [])
             if values["items"]:

--- a/ack/clients/google_dcm/client.py
+++ b/ack/clients/google_dcm/client.py
@@ -29,7 +29,7 @@ DOWNLOAD_FORMAT = "CSV"
 
 class GoogleDCMClient:
     API_NAME = "dfareporting"
-    API_VERSION = "v3.3"
+    API_VERSION = "v3.5"
 
     def __init__(self, access_token, client_id, client_secret, refresh_token):
         self._credentials = client.GoogleCredentials(

--- a/ack/clients/google_dcm/client.py
+++ b/ack/clients/google_dcm/client.py
@@ -17,6 +17,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from ack.config import logger
+from ack.utils.exceptions import FilterNotFoundError
 import httplib2
 import requests
 
@@ -90,7 +91,7 @@ class GoogleDCMClient:
                 if filter_value:
                     report["criteria"]["dimensionFilters"].append(filter_value)
                 else:
-                    logger.info(f"Filter not found: {dimension_name} - {dimension_value}")
+                    raise FilterNotFoundError(f"Filter not found: {dimension_name} - {dimension_value}")
 
     def run_report(self, report, profile_id):
         inserted_report = self._service.reports().insert(profileId=profile_id, body=report).execute()

--- a/ack/readers/google_dcm/cli.py
+++ b/ack/readers/google_dcm/cli.py
@@ -36,13 +36,13 @@ from ack.utils.processor import processor
     "--dcm-metric",
     "dcm_metrics",
     multiple=True,
-    help="https://developers.google.com/doubleclick-advertisers/v3.3/dimensions/#standard-metrics",
+    help="https://developers.google.com/doubleclick-advertisers/v3.5/dimensions/#standard-metrics",
 )
 @click.option(
     "--dcm-dimension",
     "dcm_dimensions",
     multiple=True,
-    help="https://developers.google.com/doubleclick-advertisers/v3.3/dimensions/#standard-dimensions",
+    help="https://developers.google.com/doubleclick-advertisers/v3.5/dimensions/#standard-dimensions",
 )
 @click.option("--dcm-start-date", type=click.DateTime(), help="Start date of the report")
 @click.option("--dcm-end-date", type=click.DateTime(), help="End date of the report")
@@ -52,7 +52,7 @@ from ack.utils.processor import processor
     type=click.Tuple([str, str]),
     multiple=True,
     help="A filter is a tuple following this pattern: (dimensionName, dimensionValue). "
-    "https://developers.google.com/doubleclick-advertisers/v3.3/dimensions/#standard-filters",
+    "https://developers.google.com/doubleclick-advertisers/v3.5/dimensions/#standard-filters",
 )
 @click.option(
     "--dcm-date-range",

--- a/ack/utils/exceptions.py
+++ b/ack/utils/exceptions.py
@@ -87,3 +87,9 @@ class ReportScheduleNotReadyError(Exception):
     """Raised when The Trade Desk report schedule is not ready yet"""
 
     pass
+
+
+class FilterNotFoundError(Exception):
+    """Raised when a dimension filter is not found"""
+
+    pass


### PR DESCRIPTION
The Campaign Manager 360 API v3.3 is deprecated and will be sunset on June 30th, 2021. All users must migrate to a newer API version by that date.

The latest version is v3.5

I also modified the function add dimension filter. Indeed, the dimensionValues().query can only retrieve 100 results, so we have to iterate using the next page token to get all the possible values. 

Moreover, I think that it is better to raise an error when the user wants to add a dimension filter with an incorrect value. Otherwise, we still make our request to the API (with no filter added). 