### PR TITLE
Scheduled queries google dbm

### DIFF
--- a/ack/readers/google_dbm/cli.py
+++ b/ack/readers/google_dbm/cli.py
@@ -17,7 +17,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import click
-from ack.readers.google_dbm.config import POSSIBLE_REQUEST_TYPES
+from ack.readers.google_dbm.config import POSSIBLE_REQUEST_TYPES, POSSIBLE_FREQUENCIES, POSSIBLE_TIMEZONE_CODES
 from ack.readers.google_dbm.reader import GoogleDBMReader
 from ack.utils.args import extract_args
 from ack.utils.processor import processor
@@ -33,7 +33,8 @@ from ack.utils.processor import processor
 @click.option("--dbm-request-type", type=click.Choice(POSSIBLE_REQUEST_TYPES), required=True)
 @click.option("--dbm-query-id")
 @click.option("--dbm-query-title")
-@click.option("--dbm-query-frequency", default="ONE_TIME")
+@click.option("--dbm-query-frequency", type=click.Choice(POSSIBLE_FREQUENCIES), default="ONE_TIME")
+@click.option("--dbm-query-timezone-code", type=click.Choice(POSSIBLE_TIMEZONE_CODES), default="America/New_York")
 @click.option("--dbm-query-param-type", default="TYPE_TRUEVIEW")
 @click.option("--dbm-start-date", type=click.DateTime())
 @click.option("--dbm-end-date", type=click.DateTime())

--- a/ack/readers/google_dbm/cli.py
+++ b/ack/readers/google_dbm/cli.py
@@ -35,6 +35,8 @@ from ack.utils.processor import processor
 @click.option("--dbm-query-title")
 @click.option("--dbm-query-frequency", type=click.Choice(POSSIBLE_FREQUENCIES), default="ONE_TIME")
 @click.option("--dbm-query-timezone-code", type=click.Choice(POSSIBLE_TIMEZONE_CODES), default="America/New_York")
+@click.option("--dbm-scheduled-start-date", type=click.DateTime())
+@click.option("--dbm-scheduled-end-date", type=click.DateTime())
 @click.option("--dbm-query-param-type", default="TYPE_TRUEVIEW")
 @click.option("--dbm-start-date", type=click.DateTime())
 @click.option("--dbm-end-date", type=click.DateTime())

--- a/ack/readers/google_dbm/config.py
+++ b/ack/readers/google_dbm/config.py
@@ -61,6 +61,9 @@ class GoogleDBMReaderConfig(BaseModel):
     query_id: str = None
     query_title: str = None
     query_frequency: str = "ONE_TIME"
+    query_timezone_code: str = "America/New_York"
+    scheduled_start_date: datetime
+    scheduled_end_date: datetime
     query_param_type: str = "TYPE_TRUEVIEW"
     start_date: datetime = None
     end_date: datetime = None

--- a/ack/readers/google_dbm/config.py
+++ b/ack/readers/google_dbm/config.py
@@ -23,9 +23,26 @@ from pydantic import BaseModel, validator
 GOOGLE_TOKEN_URI = "https://accounts.google.com/o/oauth2/token"
 
 DAY_RANGES = ("PREVIOUS_DAY", "LAST_30_DAYS", "LAST_90_DAYS", "LAST_7_DAYS", "PREVIOUS_MONTH", "PREVIOUS_WEEK")
+POSSIBLE_FREQUENCIES = ("DAILY", "MONTHLY", "ONE_TIME", "QUARTERLY", "SEMI_MONTHLY", "WEEKLY")
+POSSIBLE_TIMEZONE_CODES = (
+    "Africa/Johannesburg",
+    "America/Los_Angeles",
+    "America/New_York",
+    "America/Sao_Paulo",
+    "Asia/Dubai",
+    "Asia/Hong_Kong",
+    "Asia/Jerusalem",
+    "Asia/Shanghai",
+    "Asia/Tokyo",
+    "Australia/Sydney",
+    "Europe/London",
+    "Europe/Paris",
+    "Pacific/Auckland",
+)
 POSSIBLE_REQUEST_TYPES = [
     "existing_query",
     "custom_query",
+    "custom_scheduled_query",
     "existing_query_report",
     "custom_query_report",
     "lineitems_objects",

--- a/ack/readers/google_dbm/config.py
+++ b/ack/readers/google_dbm/config.py
@@ -60,8 +60,8 @@ class GoogleDBMReaderConfig(BaseModel):
     request_type: Literal[tuple(POSSIBLE_REQUEST_TYPES)]
     query_id: str = None
     query_title: str = None
-    query_frequency: str = "ONE_TIME"
-    query_timezone_code: str = "America/New_York"
+    query_frequency: Literal[tuple(POSSIBLE_FREQUENCIES)]
+    query_timezone_code: Literal[tuple(POSSIBLE_TIMEZONE_CODES)]
     scheduled_start_date: datetime
     scheduled_end_date: datetime
     query_param_type: str = "TYPE_TRUEVIEW"

--- a/ack/readers/google_dbm/reader.py
+++ b/ack/readers/google_dbm/reader.py
@@ -26,7 +26,11 @@ from ack.config import logger
 from ack.readers.google_dbm.config import GOOGLE_TOKEN_URI
 from ack.readers.reader import Reader
 from ack.streams.format_date_stream import FormatDateStream
-from ack.utils.date_handler import check_date_range_definition_conformity, get_date_start_and_date_stop_from_date_range
+from ack.utils.date_handler import (
+    check_date_range_definition_conformity,
+    check_scheduled_parameters_definition_conformity,
+    get_date_start_and_date_stop_from_date_range,
+)
 from ack.utils.text import get_report_generator_from_flat_file, skip_last
 from oauth2client import GOOGLE_REVOKE_URI, client
 from tenacity import retry, stop_after_delay, wait_exponential
@@ -55,12 +59,19 @@ class GoogleDBMReader(Reader):
 
         self.kwargs = kwargs
 
-        if self.kwargs.get("query_frequency") == "ONE_TIME":
+        is_scheduled_report = self.kwargs.get("request_type") == "custom_scheduled_query"
+
+        if not is_scheduled_report:
             check_date_range_definition_conformity(
                 self.kwargs.get("start_date"), self.kwargs.get("end_date"), self.kwargs.get("day_range")
             )
         else:
-            check_date_range_definition_conformity(self.kwargs.get("start_date"), self.kwargs.get("end_date"), None)
+            check_scheduled_parameters_definition_conformity(
+                self.kwargs.get("scheduled_start_date"),
+                self.kwargs.get("scheduled_end_date"),
+                self.kwargs.get("query_frequency"),
+                self.kwargs.get("day_range"),
+            )
 
     def get_query(self, query_id):
         if query_id:
@@ -76,8 +87,8 @@ class GoogleDBMReader(Reader):
         else:
             raise ClickException(f"No query found with the id {query_id}")
 
-    def get_query_body(self, scheduled):
-        scheduled_body = self.create_scheduled_body(scheduled)
+    def get_query_body(self, is_scheduled):
+        scheduled_body = self.create_scheduled_body(is_scheduled)
         body_q = {
             "kind": "doubleclickbidmanager#query",
             "metadata": {
@@ -93,7 +104,7 @@ class GoogleDBMReader(Reader):
             },
             "schedule": scheduled_body,
         }
-        if not scheduled and self.kwargs.get("start_date") is not None and self.kwargs.get("end_date") is not None:
+        if not is_scheduled and self.kwargs.get("start_date") is not None and self.kwargs.get("end_date") is not None:
             body_q["metadata"]["dataRange"] = "CUSTOM_DATES"
             body_q["reportDataStartTimeMs"] = 1000 * int(
                 (self.kwargs.get("start_date") + datetime.timedelta(days=1)).timestamp()
@@ -101,19 +112,19 @@ class GoogleDBMReader(Reader):
             body_q["reportDataEndTimeMs"] = 1000 * int((self.kwargs.get("end_date") + datetime.timedelta(days=1)).timestamp())
         return body_q
 
-    def create_scheduled_body(self, scheduled):
-        if not scheduled:
+    def create_scheduled_body(self, is_scheduled):
+        if not is_scheduled:
             return {"frequency": "ONE_TIME"}
         else:
             return {
                 "frequency": self.kwargs.get("query_frequency"),
                 "nextRunTimezoneCode": self.kwargs.get("query_timezone_code"),
-                "endTimeMs": 1000 * int((self.kwargs.get("end_date") + datetime.timedelta(days=1)).timestamp()),
-                "startTimeMs": 1000 * int((self.kwargs.get("start_date") + datetime.timedelta(days=1)).timestamp()),
+                "endTimeMs": 1000 * int((self.kwargs.get("scheduled_end_date") + datetime.timedelta(days=1)).timestamp()),
+                "startTimeMs": 1000 * int((self.kwargs.get("scheduled_start_date") + datetime.timedelta(days=1)).timestamp()),
             }
 
-    def create_and_get_query(self, scheduled=False):
-        body_query = self.get_query_body(scheduled)
+    def create_and_get_query(self, is_scheduled=False):
+        body_query = self.get_query_body(is_scheduled)
         query = self._client.queries().createquery(body=body_query).execute()
         return query
 
@@ -191,9 +202,9 @@ class GoogleDBMReader(Reader):
         if request_type == "existing_query":
             data = [self.get_existing_query()]
         elif request_type == "custom_query":
-            data = [self.create_and_get_query(scheduled=False)]
+            data = [self.create_and_get_query(is_scheduled=False)]
         elif request_type == "custom_scheduled_query":
-            data = [self.create_and_get_query(scheduled=True)]
+            data = [self.create_and_get_query(is_scheduled=True)]
         elif request_type == "existing_query_report":
             data = self.get_query_report(existing_query=True)
         elif request_type == "custom_query_report":

--- a/ack/utils/date_handler.py
+++ b/ack/utils/date_handler.py
@@ -69,6 +69,24 @@ def check_date_range_definition_conformity(start_date: date, end_date: date, dat
             raise DateDefinitionException("Report end date should be equal or ulterior to report start date.")
 
 
+def check_scheduled_parameters_definition_conformity(
+    scheduled_start_date: date, scheduled_end_date: date, frequency: str, date_range: str
+):
+
+    if not date_range:
+        raise DateDefinitionException("You must define a date_range for a scheduled report")
+    elif not frequency:
+        raise DateDefinitionException("You must define a frequency for a scheduled report")
+    else:
+        if not all([scheduled_start_date, scheduled_end_date]):
+            raise DateDefinitionException("You must define a couple (scheduled-start-date, scheduled-end-date)")
+        elif scheduled_end_date < scheduled_start_date:
+            raise DateDefinitionException(
+                "Report scheduled-end-date should be equal or ulterior to report \
+            scheduled-start-date."
+            )
+
+
 def get_date_start_and_date_stop_from_date_range(date_range: str) -> Tuple[date, date]:
     """Returns date start and date stop based on the date range provided
     and the current date.

--- a/docs/source/readers.rst
+++ b/docs/source/readers.rst
@@ -724,10 +724,13 @@ CMD Options                     JSON Options                 Definition
 ``--dbm-client-secret``         ``client_secret``            OAuth2 secret
 ``--dbm-access-token``          ``access_token``             (Optional) Access token for OAuth2
 ``--dbm-refresh-token``         ``refresh_token``            Refresh token for OAuth2
-``--dbm-query-request-type``    ``query_request_type``       Doubleclick Bid Manager API request type. Possible values: existing_query, custom_query, existing_query_report, custom_query_report, lineitems_objects, sdf_objects and list_reports.
+``--dbm-query-request-type``    ``query_request_type``       Doubleclick Bid Manager API request type. Possible values: existing_query, custom_query, existing_query_report, custom_query_report, custom_scheduled_query, lineitems_objects, sdf_objects and list_reports.
 ``--dbm-query-id``              ``query_id``                 Query ID.
 ``--dbm-query-title``           ``query_title``              Query title, used to name the reports generated from this query in DV360 UI.
 ``--dbm-query-frequency``       ``query_frequency``          How often the query is run. Possible values can be found `here <https://developers.google.com/bid-manager/v1/queries#schedule.frequency>`__. Default: ONE_TIME.
+``--dbm-query-timezone-code``   ``query_timezone_code``      Canonical timezone code for report generation time. Defaults to America/New_York.  
+``--dbm-scheduled-start-date``  ``scheduled_start_date``     Date to start running scheduled query, in milliseconds since the Unix epoch. Not applicable to ONE_TIME frequency.
+``--dbm-scheduled-end-date``    ``scheduled_end_date``       Date to stop running scheduled query, in milliseconds since the Unix epoch.
 ``--dbm-filter``                ``filter`` (list(tuple))     <FILTER_TYPE> <FILTER_VALUE> association, used to narrow the scope of the report. For instance "FILTER_ADVERTISER XXXXX" will narrow report scope to the performance of Advertiser ID XXXXX. Possible filter types can be found `here <https://developers.google.com/bid-manager/v1/filters-metrics#filters)>`__.
 ``--dbm-query-dimension``       ``query_dimension`` (list)   Dimensions to include in the report. Possible values can be found `here <https://developers.google.com/bid-manager/v1/filters-metrics#filters>`__.
 ``--dbm-query-metric``          ``query_metric`` (list)      Metrics to include in the report. Possible values can be found `here <https://developers.google.com/bid-manager/v1/filters-metrics#metrics>`__.

--- a/tests/readers/google_dbm/test_reader.py
+++ b/tests/readers/google_dbm/test_reader.py
@@ -46,7 +46,7 @@ class TestGoogleDBMReader(unittest.TestCase):
             "schedule": {"frequency": "ONE_TIME"},
         }
 
-        self.assertDictEqual(reader.get_query_body(scheduled=False), expected_query_body)
+        self.assertDictEqual(reader.get_query_body(is_scheduled=False), expected_query_body)
 
     @mock.patch.object(GoogleDBMReader, "__init__", mock_dbm_reader)
     def test_get_query_body_ms_conversion(self):
@@ -71,7 +71,7 @@ class TestGoogleDBMReader(unittest.TestCase):
             "reportDataStartTimeMs": 1579132800000,
             "reportDataEndTimeMs": 1579392000000,
         }
-        self.assertDictEqual(reader.get_query_body(scheduled=False), expected_query_body)
+        self.assertDictEqual(reader.get_query_body(is_scheduled=False), expected_query_body)
 
     @mock.patch.object(GoogleDBMReader, "__init__", mock_dbm_reader)
     def test_get_scheduled_query_body_ms_conversion(self):

--- a/tests/readers/google_dbm/test_reader.py
+++ b/tests/readers/google_dbm/test_reader.py
@@ -29,7 +29,7 @@ class TestGoogleDBMReader(unittest.TestCase):
             setattr(self, param, value)
 
     @mock.patch.object(GoogleDBMReader, "__init__", mock_dbm_reader)
-    def test_get_query_body(self):
+    def test_get_query_body_not_scheduled(self):
         kwargs = {}
         reader = GoogleDBMReader(**kwargs)
         reader.kwargs = {"filter": [("FILTER_ADVERTISER", 1)]}
@@ -46,7 +46,7 @@ class TestGoogleDBMReader(unittest.TestCase):
             "schedule": {"frequency": "ONE_TIME"},
         }
 
-        self.assertDictEqual(reader.get_query_body(), expected_query_body)
+        self.assertDictEqual(reader.get_query_body(scheduled=False), expected_query_body)
 
     @mock.patch.object(GoogleDBMReader, "__init__", mock_dbm_reader)
     def test_get_query_body_ms_conversion(self):
@@ -71,4 +71,35 @@ class TestGoogleDBMReader(unittest.TestCase):
             "reportDataStartTimeMs": 1579132800000,
             "reportDataEndTimeMs": 1579392000000,
         }
-        self.assertDictEqual(reader.get_query_body(), expected_query_body)
+        self.assertDictEqual(reader.get_query_body(scheduled=False), expected_query_body)
+
+    @mock.patch.object(GoogleDBMReader, "__init__", mock_dbm_reader)
+    def test_get_scheduled_query_body_ms_conversion(self):
+        kwargs = {}
+        reader = GoogleDBMReader(**kwargs)
+        reader.kwargs = {
+            "filter": [("FILTER_ADVERTISER", 1)],
+            "start_date": datetime.datetime(2020, 1, 15, tzinfo=datetime.timezone.utc),
+            "end_date": datetime.datetime(2020, 1, 18, tzinfo=datetime.timezone.utc),
+            "day_range": "LAST_7_DAYS",
+            "query_timezone_code": "America/New_York",
+            "query_frequency": "DAILY",
+        }
+
+        expected_query_body = {
+            "kind": "doubleclickbidmanager#query",
+            "metadata": {"format": "CSV", "title": "NO_TITLE_GIVEN", "dataRange": "LAST_7_DAYS"},
+            "params": {
+                "type": "TYPE_TRUEVIEW",
+                "groupBys": [],
+                "metrics": [],
+                "filters": [{"type": "FILTER_ADVERTISER", "value": "1"}],
+            },
+            "schedule": {
+                "frequency": "DAILY",
+                "nextRunTimezoneCode": "America/New_York",
+                "endTimeMs": 1579392000000,
+                "startTimeMs": 1579132800000,
+            },
+        }
+        self.assertDictEqual(reader.get_query_body(scheduled=True), expected_query_body)

--- a/tests/readers/google_dbm/test_reader.py
+++ b/tests/readers/google_dbm/test_reader.py
@@ -79,8 +79,8 @@ class TestGoogleDBMReader(unittest.TestCase):
         reader = GoogleDBMReader(**kwargs)
         reader.kwargs = {
             "filter": [("FILTER_ADVERTISER", 1)],
-            "start_date": datetime.datetime(2020, 1, 15, tzinfo=datetime.timezone.utc),
-            "end_date": datetime.datetime(2020, 1, 18, tzinfo=datetime.timezone.utc),
+            "scheduled_start_date": datetime.datetime(2020, 1, 15, tzinfo=datetime.timezone.utc),
+            "scheduled_end_date": datetime.datetime(2020, 1, 18, tzinfo=datetime.timezone.utc),
             "day_range": "LAST_7_DAYS",
             "query_timezone_code": "America/New_York",
             "query_frequency": "DAILY",
@@ -102,4 +102,4 @@ class TestGoogleDBMReader(unittest.TestCase):
                 "startTimeMs": 1579132800000,
             },
         }
-        self.assertDictEqual(reader.get_query_body(scheduled=True), expected_query_body)
+        self.assertDictEqual(reader.get_query_body(is_scheduled=True), expected_query_body)


### PR DESCRIPTION
The goal of this PR is to enable the creation of scheduled reports for Google DBM reader. 

To do so, I added a function that creates the "schedule" body of the query depending on the query request type.

Moreover, I added the the possible values for the timezone codes and the frequencies in cli.py