### PR TITLE
Update dcm client.py to allow report criteria flexibility

### DIFF
--- a/ack/clients/google_dcm/client.py
+++ b/ack/clients/google_dcm/client.py
@@ -63,7 +63,17 @@ class GoogleDCMClient:
             "dimensions": [{"name": dim} for dim in dimensions],
             "metricNames": metrics,
         }
-        report["criteria"] = criteria
+        if report['type'] == 'REACH':
+            report['reachCriteria'] = criteria
+        elif report['type'] == 'PATH_TO_CONVERSION':
+            report['pathToConversionCriteria'] = criteria
+        elif report['type'] == 'FLOODLIGHT':
+            report['floodlightCriteria'] = criteria
+        elif report['type'] == 'CROSS_DIMENSION_REACH':
+            report['crossDimensionReachCriteria'] = criteria
+        else: # Standard Report Criteria
+            report['criteria'] = criteria
+        
 
     def add_dimension_filters(self, report, profile_id, filters):
         for dimension_name, dimension_value in filters:


### PR DESCRIPTION
Small code change added to client.py to allow for more DCM reports than just the standard report. The default code was only allowing the standard report to be called, this adds functionality to allow the additional 4 reports via CM360 to be called.

More information can be found at https://developers.google.com/doubleclick-advertisers/guides/create_reports#python in the 'Define the report criteria section' of the CM API Documentation.