### PR TITLE
update/fb-requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ colorama==0.4.3
 curlify==2.2.1
 docopt==0.6.2
 docutils==0.15.2
-facebook-business==10.0.0
+facebook-business==12.0.0
 google-api-core==1.14.3
 google-api-python-client==1.4.2
 google-auth==1.28.0


### PR DESCRIPTION
Update requirements for Facebook business (all versions prior to v11.0 will be deprecating on Monday, October 4, 2021)