### PR TITLE
update/twitter-ads-requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ uritemplate==3.0.0
 urllib3==1.25.8
 Werkzeug==0.16.0
 googleads==22.0.0
-twitter-ads==8.0.0
+twitter-ads==9.0.0
 pyjwt==1.7.1
 cryptography==3.3.2
 bs4==0.0.1


### PR DESCRIPTION
Small change to update the Twitter Ads version in the requirements.txt. Version 8.0 is no more, current version is now Version 9.0