### PR TITLE
Build errors with new version of pip and MacOS

### DIFF
--- a/.github/workflows/deploy_doc.yaml
+++ b/.github/workflows/deploy_doc.yaml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 

--- a/.github/workflows/deploy_image.yml
+++ b/.github/workflows/deploy_image.yml
@@ -17,7 +17,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # TO CONFIGURE THIS WORKFLOW
-# 1. Set up secrets in your workspace: 
+# 1. Set up secrets in your workspace:
 # - GCP_PROJECT with the name of the project
 # - GCP_EMAIL with the service account email
 # - GCP_KEY with the service account key
@@ -41,6 +41,17 @@ env:
   CLOUDSDK_PYTHON_SITEPACKAGES: 1
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build and publish Docker image
+        run: |
+          make build_base_image
 
   build-and-deploy:
 
@@ -50,7 +61,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/deploy_image.yml
+++ b/.github/workflows/deploy_image.yml
@@ -41,17 +41,6 @@ env:
   CLOUDSDK_PYTHON_SITEPACKAGES: 1
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Build and publish Docker image
-        run: |
-          make build_base_image
 
   build-and-deploy:
 

--- a/.github/workflows/lint_and_run_tests.yml
+++ b/.github/workflows/lint_and_run_tests.yml
@@ -29,18 +29,18 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
     
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt        
+          pip install -r requirements.txt --upgrade --no-cache-dir --use-deprecated=legacy-resolver
+          pip install -r requirements-dev.txt
     
       - name: Lint with flake8
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM python:3.8-buster
+FROM python:3.8-slim-buster
 
 ENV PYTHONDONTWRITEBYTECODE True
 ENV PYTHONUNBUFFERED True
 
 ADD requirements.txt .
+
+RUN apt update -y
+RUN apt install -y build-essential
+
 RUN python -m pip install --upgrade pip
 RUN python -m pip install -r requirements.txt --use-deprecated=legacy-resolver
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV PYTHONDONTWRITEBYTECODE True
 ENV PYTHONUNBUFFERED True
 
 ADD requirements.txt .
+RUN python -m pip install --upgrade pip
 RUN python -m pip install -r requirements.txt --use-deprecated=legacy-resolver
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-buster
 
 ENV PYTHONDONTWRITEBYTECODE True
 ENV PYTHONUNBUFFERED True
 
 ADD requirements.txt .
-RUN python -m pip install -r requirements.txt
+RUN python -m pip install -r requirements.txt --use-deprecated=legacy-resolver
 
 WORKDIR /app
 ADD . /app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 black==19.10b0
 flake8==3.8.3
 freezegun==0.3.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ lxml==4.6.3
 MarkupSafe==1.1.1
 more-itertools==8.0.2
 num2words==0.5.10
-numpy==1.20.2
+numpy==1.21.2
 oauth2client==1.5.2
 prettytable==0.7.2
 protobuf==3.11.1
@@ -57,7 +57,7 @@ tenacity==6.0.0
 unicode-slugify==0.1.3
 Unidecode==1.1.1
 uritemplate==3.0.0
-urllib3==1.25.8
+urllib3==1.25.10
 Werkzeug==0.16.0
 googleads==22.0.0
 twitter-ads==9.0.0


### PR DESCRIPTION
- Fixes the error that occurs when running `pip install googleanalytics` which depends on a old version of `keyring` `ERROR: No matching distribution found for keyring==5.3`
- Bump `numpy` to a newer version to be able to support compilation with ARM chips on Mac OS.
- Cleanup the `Dockerfile` and one GitHub Actions workflow : `gcc` was needed at some point during the global `pip install`

References: https://stackoverflow.com/questions/67074684/pip-has-problems-with-metadata
