### PR TITLE
Feat/awin add date to api

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PROJECT_ID=artefact-docker-containers
 DOCKER_IMAGE=artefactory-connectors-kit-dev
-DOCKER_TAG=v2.3
+DOCKER_TAG=v2.1.2
 DOCKER_REGISTRY=eu.gcr.io

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PROJECT_ID=artefact-docker-containers
 DOCKER_IMAGE=artefactory-connectors-kit-dev
-DOCKER_TAG=v2.2
+DOCKER_TAG=v2.3
 DOCKER_REGISTRY=eu.gcr.io

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PROJECT_ID=artefact-docker-containers
 DOCKER_IMAGE=artefactory-connectors-kit-dev
-DOCKER_TAG=v2.1
+DOCKER_TAG=v2.2
 DOCKER_REGISTRY=eu.gcr.io

--- a/ack/readers/awin_advertiser/reader.py
+++ b/ack/readers/awin_advertiser/reader.py
@@ -70,6 +70,12 @@ class AwinAdvertiserReader(Reader):
             build_url, params=payload
         )
         json_response = response.json()
+        
+        # there is no date in API response, add this in here
+        for entry in json_response:
+            if not 'date' in entry and self.start_date == self.end_date:
+                entry['date'] = self.start_date
+        
         # if report is not a campaign report, remove tags from the response
         if self.remove_tags and self.report_type != REPORT_TYPES[2]:
             for element in json_response:

--- a/ack/readers/awin_advertiser/reader.py
+++ b/ack/readers/awin_advertiser/reader.py
@@ -70,12 +70,11 @@ class AwinAdvertiserReader(Reader):
             build_url, params=payload
         )
         json_response = response.json()
-        
         # there is no date in API response, add this in here
         for entry in json_response:
-            if not 'date' in entry and self.start_date == self.end_date:
+            if 'date' not in entry and self.start_date == self.end_date:
                 entry['date'] = self.start_date
-        
+
         # if report is not a campaign report, remove tags from the response
         if self.remove_tags and self.report_type != REPORT_TYPES[2]:
             for element in json_response:


### PR DESCRIPTION
### Issue

- The API doesn't output a date, this can be troublesome for Berlioz, which works closely with ACK.

### Description

- This PR adds the start_date from the reader CLI request, only if the start_date and end_date match, and only if the date is not part of the json response from the API.