### PR TITLE
upgrade facebook-business version

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PROJECT_ID=artefact-docker-containers
 DOCKER_IMAGE=artefactory-connectors-kit-dev
-DOCKER_TAG=v2.1.2
+DOCKER_TAG=v2.1.5
 DOCKER_REGISTRY=eu.gcr.io

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ colorama==0.4.3
 curlify==2.2.1
 docopt==0.6.2
 docutils==0.15.2
-facebook-business==12.0.0
+facebook-business==16.0.0
 google-api-core==1.14.3
 google-api-python-client==1.4.2
 google-auth==1.28.0


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] Upgrade facebook-business package as FB would deprecate support for versions below v15.

### Description

- [ ] changed the version of the image and upgraded the facebook-business==16.0.0

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does